### PR TITLE
add colorsheet and use variables

### DIFF
--- a/css/camera_controls.css
+++ b/css/camera_controls.css
@@ -9,12 +9,12 @@
 
 .cc-container .btn {
     border: none;
-    color: #d8d8d8;
-    background-color: #25222e;
+    color: var(--white-one);
+    background-color: var(--black-one);
 }
 
 .cc-container .btn:hover {
     border: none;
-    color: #d8d8d8;
-    background-color: #4A4658;
+    color: var(--white-one);
+    background-color: var(--gray-one);
 }

--- a/css/camera_controls.css
+++ b/css/camera_controls.css
@@ -13,8 +13,12 @@
     background-color: var(--dark-one);
 }
 
-.cc-container .btn:hover {
+/* using id selectors to override antd styling
+without using !important tag */
+#reset-button:hover,
+#zoomin-button:hover,
+#zoomout-button:hover {
     border: none;
-    color: var(--white-one) !important;
+    color: var(--white-one);
     background-color: var(--gray-one);
 }

--- a/css/camera_controls.css
+++ b/css/camera_controls.css
@@ -15,6 +15,6 @@
 
 .cc-container .btn:hover {
     border: none;
-    color: var(--white-one);
+    color: var(--white-one) !important;
     background-color: var(--gray-one);
 }

--- a/css/camera_controls.css
+++ b/css/camera_controls.css
@@ -10,7 +10,7 @@
 .cc-container .btn {
     border: none;
     color: var(--white-one);
-    background-color: var(--black-one);
+    background-color: var(--dark-one);
 }
 
 .cc-container .btn:hover {

--- a/css/colors.css
+++ b/css/colors.css
@@ -2,5 +2,5 @@
   --black-one: #000000;
   --white-one: #d8d8d8;
   --dark-one: #25222e;
-  --gray-two: #4a4658;
+  --gray-one: #4a4658;
 }

--- a/css/colors.css
+++ b/css/colors.css
@@ -1,5 +1,6 @@
 :root {
+  --black-one: #000000;
   --white-one: #d8d8d8;
-  --black-one: #25222e;
+  --dark-one: #25222e;
   --gray-two: #4a4658;
 }

--- a/css/colors.css
+++ b/css/colors.css
@@ -1,0 +1,5 @@
+:root {
+  --white-one: #d8d8d8;
+  --black-one: #25222e;
+  --gray-two: #4a4658;
+}

--- a/css/widget.css
+++ b/css/widget.css
@@ -1,7 +1,9 @@
+@import url('colors.css');
+
 .custom-widget {
-  background-color: blueviolet;
+  background-color: var(--white-one);
   padding: 0px 2px;
-  color: black;
+  color: var(--black-one);
   margin: 20px;
   height: 300px;
   height: 100%;

--- a/src/components/CameraControls.tsx
+++ b/src/components/CameraControls.tsx
@@ -23,6 +23,7 @@ const CameraControls: React.FunctionComponent<CameraControlsProps> = (
         color={TOOLTIP_COLOR}
       >
         <Button
+          id={'zoomin-button'}
           className="btn"
           icon={ZoomIn}
           onClick={props.controller.zoomIn}
@@ -34,6 +35,7 @@ const CameraControls: React.FunctionComponent<CameraControlsProps> = (
         color={TOOLTIP_COLOR}
       >
         <Button
+          id={'zoomout-button'}
           className="btn"
           icon={ZoomOut}
           onClick={props.controller.zoomOut}
@@ -41,6 +43,7 @@ const CameraControls: React.FunctionComponent<CameraControlsProps> = (
       </Tooltip>
       <Tooltip placement="left" title="Home view (H)" color={TOOLTIP_COLOR}>
         <Button
+          id={'reset-button'}
           className="btn"
           icon={Reset}
           onClick={props.controller.resetCamera}


### PR DESCRIPTION
Closes #6 

This adds `colors.css` which defines colors at the root level, and imports them into widget.css.

Colors are imported into `widget.css`. We only need to import once to make these colors globally accessible by other stylesheets.

To confirm that its working:
-open the notebook and see that the colors are applied correctly