### PR TITLE
remove info icon and related functions and html elements

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ dist
 coverage
 **/*.d.ts
 tests
+src/__tests__

--- a/.eslintignore
+++ b/.eslintignore
@@ -3,4 +3,3 @@ dist
 coverage
 **/*.d.ts
 tests
-src/__tests__

--- a/.eslintignore
+++ b/.eslintignore
@@ -2,4 +2,4 @@ node_modules
 dist
 coverage
 **/*.d.ts
-tests
+src/__tests__

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,12 +3,12 @@ module.exports = {
     'eslint:recommended',
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
-    'plugin:prettier/recommended'
+    'plugin:prettier/recommended',
   ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     project: 'tsconfig.eslint.json',
-    sourceType: 'module'
+    sourceType: 'module',
   },
   plugins: ['@typescript-eslint'],
   rules: {
@@ -19,10 +19,10 @@ module.exports = {
     '@typescript-eslint/quotes': [
       'error',
       'single',
-      { avoidEscape: true, allowTemplateLiterals: false }
+      { avoidEscape: true, allowTemplateLiterals: false },
     ],
     curly: ['error', 'all'],
     eqeqeq: 'error',
-    'prefer-arrow-callback': 'error'
-  }
+    'prefer-arrow-callback': 'error',
+  },
 };

--- a/css/model_display_data.css
+++ b/css/model_display_data.css
@@ -9,20 +9,3 @@
   width: 100%;
   z-index: 10;
 }
-
-.info-button {
-  padding-left: 7px;
-}
-
-.info-button svg {
-  background-color: var(--black-one);
-  color: var(--white-one);
-}
-
-.info-button svg:hover {
-  color: var(--light-purple);
-}
-
-.info-button svg:active {
-  color: var(--purple-one);
-}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lint": "eslint . --ext .ts,.tsx --fix",
     "lint:check": "eslint . --ext .ts,.tsx",
     "prepack": "yarn run build:lib",
-    "test": "jest",
+    "test": "yarn jest",
     "watch": "npm-run-all -p watch:lib watch:nbextension watch:labextension",
     "watch:lib": "tsc -w",
     "watch:nbextension": "webpack --watch --mode=development",

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -1,6 +1,7 @@
 import SimulariumViewer, {
   RenderStyle,
   SimulariumController,
+  TrajectoryFileInfo,
 } from '@aics/simularium-viewer';
 import React, { useEffect, useRef, useState } from 'react';
 
@@ -15,10 +16,7 @@ import {
   VIEWER_INITIAL_WIDTH,
   agentColors,
 } from './constants';
-import {
-  ModelInfo,
-  TrajectoryFileInfo,
-} from '@aics/simularium-viewer/type-declarations/simularium/types';
+import { ModelInfo } from '@aics/simularium-viewer/type-declarations/simularium/types';
 
 import '../css/viewer.css';
 

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -1,15 +1,9 @@
 import React from 'react';
-import {
-  PlusOutlined,
-  MinusOutlined,
-  HomeOutlined,
-  InfoCircleFilled,
-} from '@ant-design/icons';
+import { PlusOutlined, MinusOutlined, HomeOutlined } from '@ant-design/icons';
 
 export const Reset = <HomeOutlined />;
 export const ZoomIn = <PlusOutlined />;
 export const ZoomOut = <MinusOutlined />;
-export const Info = <InfoCircleFilled />;
 
 export default {
   Reset,

--- a/src/components/ModelDisplayData.tsx
+++ b/src/components/ModelDisplayData.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
-
-import { Info } from './Icons';
+import { ModelInfo } from '@aics/simularium-viewer/type-declarations/simularium/types';
 
 import '../../css/model_display_data.css';
-import { ModelInfo } from '@aics/simularium-viewer/type-declarations/simularium/types';
 
 interface ModelDisplayDataProps extends ModelInfo {
   trajectoryTitle?: string;
@@ -14,21 +12,9 @@ const ModelDisplayData: React.FunctionComponent<ModelDisplayDataProps> = (
 ): JSX.Element => {
   const { title, trajectoryTitle } = props;
 
-  const hasMetaData = (): boolean => {
-    for (const key in props) {
-      if (key !== 'trajectoryTitle') {
-        if (props[key as keyof ModelDisplayDataProps] !== undefined) {
-          return true;
-        }
-      }
-    }
-    return false;
-  };
-
   return (
     <div className="model-display-data-container">
       {trajectoryTitle || title || '<Untitled trajectory>'}
-      {hasMetaData() ? <div className="info-button"> {Info} </div> : null}
     </div>
   );
 };


### PR DESCRIPTION
Per discussion with Blair yesterday we are de-prioritizing meta data panel until after MVP, so there is no need to have information button for now.

This PR also includes a line in package.json that seems to be the latest needed thing in our struggles with windows build failures, I hope this is a more long term fix:
test script is now `yarn jest` instead of `jest`