### PR TITLE
disable pan and focus functionality on viewer render

### DIFF
--- a/css/camera_controls.css
+++ b/css/camera_controls.css
@@ -1,9 +1,6 @@
 .camera-controls-container {
     display: flex;
     flex-direction: column;
-    position: absolute;
-    right: 40px;
-    bottom: 20px;
     gap: 3px;
 }
 

--- a/css/colors.css
+++ b/css/colors.css
@@ -4,8 +4,10 @@
   --dark-one: #25222e;
   --dark-two: #141219;
   --dark-three: #1e1b26;
+  --dark-four: #3d384b;
   --gray-one: #4a4658;
   --gray-two: #d3d3d3;
+  --gray-three: #a0a0a0;
   --purple-one: #b59ff6;
   --light-purple: #d0c7ed;
 }

--- a/css/scale_bar.css
+++ b/css/scale_bar.css
@@ -1,0 +1,8 @@
+.scale-bar {
+  display: flex;
+  flex-direction: column;
+  background-color: transparent;
+  color: var(--gray-three);
+  margin-bottom: 8px;
+  text-align: center;
+}

--- a/css/viewer.css
+++ b/css/viewer.css
@@ -6,5 +6,16 @@
 }
 
 .viewer-container {
+  display: flex;
   position: relative;
+  flex-direction: column;
+}
+
+.scalebar-controls {
+  align-items: flex-end;
+  display: flex;
+  gap: 30px;
+  position: absolute;
+  bottom: 30px;
+  right: 50px;
 }

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 227,
    "metadata": {
     "tags": []
    },
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 228,
    "metadata": {
     "tags": []
    },
@@ -103,7 +103,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7c35de3faa104c5fbb4f682b0d481515",
+       "model_id": "f606babadc2a4f05907751b8fa54b3a7",
        "version_major": 2,
        "version_minor": 0
       },

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -44,7 +44,7 @@ function ViewerWidget(props: WidgetProps): JSX.Element {
   const observerRef = useRef<ResizeObserver | null>(null);
 
   useEffect(() => {
-    controller.disablePan();
+    controller.setAllowViewPanning(false);
     controller.setFocusMode(false);
   }, []);
 

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -29,6 +29,7 @@ export interface WidgetProps {
 }
 
 function ViewerWidget(props: WidgetProps): JSX.Element {
+  const controller = props.controller;
   const [modelInfo, setModelInfo] = useState<ModelInfo | undefined>({});
   const [trajectoryTitle, setTrajectoryTitle] = useState<string | undefined>(
     ''
@@ -41,6 +42,11 @@ function ViewerWidget(props: WidgetProps): JSX.Element {
 
   const containerRef = useRef<HTMLDivElement>(null);
   const observerRef = useRef<ResizeObserver | null>(null);
+
+  useEffect(() => {
+    controller.disablePan();
+    controller.setFocusMode(false);
+  }, []);
 
   useEffect(() => {
     // Initialize ResizeObserver if it doesn't exist

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -1,14 +1,16 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { WidgetModel } from '@jupyter-widgets/base';
 import SimulariumViewer, {
   RenderStyle,
   SimulariumController,
   TrajectoryFileInfo,
 } from '@aics/simularium-viewer';
-import React, { useEffect, useRef, useState } from 'react';
+import { ModelInfo } from '@aics/simularium-viewer/type-declarations/simularium/types';
 
-import { WidgetModel } from '@jupyter-widgets/base';
 import CameraControls from './components/CameraControls';
 import ModelDisplayData from './components/ModelDisplayData';
 import SidePanel from './components/SidePanel';
+import ScaleBar from './components/ScaleBar';
 import {
   MIN_WIDTH_TO_SHOW_SIDE_PANEL,
   SIDE_PANEL_WIDTH,
@@ -16,7 +18,6 @@ import {
   VIEWER_INITIAL_WIDTH,
   agentColors,
 } from './constants';
-import { ModelInfo } from '@aics/simularium-viewer/type-declarations/simularium/types';
 
 import '../css/viewer.css';
 
@@ -24,21 +25,24 @@ export interface WidgetModelWithState extends WidgetModel {
   controller: SimulariumController;
 }
 
-export interface WidgetProps {
+export interface ViewerProps {
   controller: SimulariumController;
 }
 
-function ViewerWidget(props: WidgetProps): JSX.Element {
-  const controller = props.controller;
-  const [modelInfo, setModelInfo] = useState<ModelInfo | undefined>({});
-  const [trajectoryTitle, setTrajectoryTitle] = useState<string | undefined>(
-    ''
-  );
+function ViewerWidget(props: ViewerProps): JSX.Element {
+  // UI display state
   const [dimensions, setDimensions] = useState({
     width: VIEWER_INITIAL_WIDTH,
     height: VIEWER_HEIGHT,
   });
   const [showSidePanel, setShowSidePanel] = useState(true);
+  const controller = props.controller;
+  // trajectory data
+  const [modelInfo, setModelInfo] = useState<ModelInfo | undefined>({});
+  const [trajectoryTitle, setTrajectoryTitle] = useState<string | undefined>(
+    ''
+  );
+  const [scaleBarLabel, setScaleBarLabel] = useState<string>('');
 
   const containerRef = useRef<HTMLDivElement>(null);
   const observerRef = useRef<ResizeObserver | null>(null);
@@ -86,6 +90,19 @@ function ViewerWidget(props: WidgetProps): JSX.Element {
   const handleTrajectoryData = (data: TrajectoryFileInfo) => {
     setTrajectoryTitle(data.trajectoryTitle);
     setModelInfo(data.modelInfo);
+    setScaleBarLabel(getScaleBarLabel(data.spatialUnits));
+  };
+
+  const getScaleBarLabel = (spatialUnits: {
+    magnitude: number;
+    name: string;
+  }): string => {
+    const tickIntervalLength = controller.tickIntervalLength;
+    let scaleBarLabelNumber = tickIntervalLength * spatialUnits.magnitude;
+    scaleBarLabelNumber = parseFloat(scaleBarLabelNumber.toPrecision(2));
+    const scaleBarLabelUnit = spatialUnits.name;
+
+    return scaleBarLabelNumber.toString() + ' ' + scaleBarLabelUnit;
   };
 
   return (
@@ -119,8 +136,11 @@ function ViewerWidget(props: WidgetProps): JSX.Element {
           showPaths={false}
           onError={console.log}
         />
+        <div className="scalebar-controls">
+          <ScaleBar label={scaleBarLabel} />
+          <CameraControls controller={props.controller} />
+        </div>
       </div>
-      <CameraControls controller={props.controller} />
     </div>
   );
 }

--- a/src/assets/svgs.tsx
+++ b/src/assets/svgs.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+export const ScaleBarIconTag = (
+  <svg
+    enable-background="new 0 0 150 75.3"
+    viewBox="0 0 150 75.3"
+    xmlns="http://www.w3.org/2000/svg"
+    width="60px"
+  >
+    <linearGradient
+      id="a"
+      gradientTransform="matrix(1 0 0 -1 0 76)"
+      gradientUnits="userSpaceOnUse"
+      x1=".3035"
+      x2="149.6965"
+      y1="19.59"
+      y2="19.59"
+    >
+      <stop offset="0" stop-color="#686868" stop-opacity="0" />
+      <stop offset=".16" stop-color="#686868" />
+      <stop offset=".84" stop-color="#686868" />
+      <stop offset="1" stop-color="#686868" stop-opacity="0" />
+    </linearGradient>
+    <g fill="none">
+      <path
+        d="m.5 39.1 149 34.6"
+        stroke="url(#a)"
+        stroke-miterlimit="10"
+        stroke-width="4"
+      />
+      <path
+        d="m101.5 73.6 22-17"
+        stroke="#686868"
+        stroke-miterlimit="10"
+        stroke-width="4"
+      />
+      <path
+        d="m25.1 55.7 22.1-17"
+        stroke="#686868"
+        stroke-miterlimit="10"
+        stroke-width="4"
+      />
+      <path
+        d="m36.2 46.7c0-12 5.3-12.4 10.5-14.2 5-1.7 17.3 1.9 22.6 1.7s8-5 8.4-11.8c-.4 6.9 3.4 13.8 10 16.3 8 3 17.9 2.7 23.2 7.3 7 6 3.3 12.2 1.6 19.1"
+        stroke="#808080"
+        stroke-dasharray="2 4"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="3"
+      />
+    </g>
+  </svg>
+);

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -1,9 +1,17 @@
 import React from 'react';
-import { PlusOutlined, MinusOutlined, HomeOutlined } from '@ant-design/icons';
+import {
+  PlusOutlined,
+  MinusOutlined,
+  HomeOutlined,
+  InfoCircleFilled,
+} from '@ant-design/icons';
+import { ScaleBarIconTag } from '../assets/svgs';
 
 export const Reset = <HomeOutlined />;
 export const ZoomIn = <PlusOutlined />;
 export const ZoomOut = <MinusOutlined />;
+export const Info = <InfoCircleFilled />;
+export const ScaleBarIcon = ScaleBarIconTag;
 
 export default {
   Reset,

--- a/src/components/ScaleBar.tsx
+++ b/src/components/ScaleBar.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+
+import { ScaleBarIcon } from './Icons';
+
+import '../../css/scale_bar.css';
+
+interface ScaleBarProps {
+  label: string;
+}
+
+const ScaleBar = (scaleBarProps: ScaleBarProps): JSX.Element => {
+  const { label } = scaleBarProps;
+  const scaleBarNode = label ? (
+    <div className="scale-bar">
+      {label}
+      {ScaleBarIcon}
+    </div>
+  ) : (
+    <div />
+  );
+
+  return scaleBarNode;
+};
+export default ScaleBar;

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -13,7 +13,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import { MODULE_NAME, MODULE_VERSION } from './version';
-import Viewer, { WidgetProps } from './Viewer';
+import Viewer, { ViewerProps } from './Viewer';
 
 // Import the CSS
 import '../css/widget.css';
@@ -71,7 +71,7 @@ export class Viewport extends DOMWidgetView {
 
     const component = React.createElement(Viewer, {
       controller: this.controller,
-    } as WidgetProps);
+    } as ViewerProps);
 
     ReactDOM.render(component, this.el);
   }


### PR DESCRIPTION
Panning and focus mode are disabled in the NBSV MVP, and that viewer method exists for disabling pan.

To confirm:
------------
Right click and drag, no panning should happen.
Select an agent by clicking on it, the camera position should not change.