### PR TITLE
agent rows with first checkbox

### DIFF
--- a/src/AgentVisibilityContext.tsx
+++ b/src/AgentVisibilityContext.tsx
@@ -2,6 +2,8 @@ import React, { createContext, useEffect, useMemo } from 'react';
 import { CheckboxState, VisibilitySelectionMap } from './constants';
 import { UIDisplayData } from '@aics/simularium-viewer';
 
+import { getNewHiddenAgents } from './selectors';
+
 interface VisibilityContextType {
   uiDisplayData: UIDisplayData;
   hiddenAgents: VisibilitySelectionMap;
@@ -9,6 +11,7 @@ interface VisibilityContextType {
   noAgentsHidden: VisibilitySelectionMap;
   receiveUIDisplayData: (data: UIDisplayData) => void;
   handleAllAgentsCheckboxChange: (hiddenState: CheckboxState) => void;
+  handleAgentCheckboxChange: (agentName: string) => void;
 }
 
 export const VisibilityContext = createContext<VisibilityContextType>({
@@ -18,6 +21,7 @@ export const VisibilityContext = createContext<VisibilityContextType>({
   noAgentsHidden: {},
   receiveUIDisplayData: () => {},
   handleAllAgentsCheckboxChange: () => {},
+  handleAgentCheckboxChange: () => {},
 });
 
 export const VisibilityProvider = ({
@@ -69,6 +73,10 @@ export const VisibilityProvider = ({
     setHiddenAgents(newHidden);
   };
 
+  const handleAgentCheckboxChange = (agentName: string) => {
+    setHiddenAgents(getNewHiddenAgents(agentName, hiddenAgents));
+  };
+
   const vis = {
     uiDisplayData,
     hiddenAgents,
@@ -76,6 +84,7 @@ export const VisibilityProvider = ({
     noAgentsHidden,
     receiveUIDisplayData,
     handleAllAgentsCheckboxChange,
+    handleAgentCheckboxChange,
   };
 
   return (

--- a/src/__tests__/selectors.spec.ts
+++ b/src/__tests__/selectors.spec.ts
@@ -1,12 +1,58 @@
-import { getSelectionStateInfo } from '../selectors';
+import { UIDisplayData } from '@aics/simularium-viewer';
+import { getNewHiddenAgents, getSelectionStateInfo } from '../selectors';
 
-  const mockVisibilitySelectionMap = {
-    agent1: ['state1'],
-    agent2: ['state1', 'state2'],
-    agent3: [],
-  };
+const mockVisibilitySelectionMap = {
+  agent1: ['agent1'],
+  agent2: ['agent2'],
+  agent3: [],
+};
 
+const mockUIDisplayData: UIDisplayData = [
+  {
+    name: 'agent1',
+    displayStates: [],
+    color: '#000000',
+  },
+  {
+    name: 'agent2',
+    displayStates: [],
+    color: '#000000',
+  },
+  {
+    name: 'agent3',
+    displayStates: [],
+    color: '#000000',
+  },
+];
+
+// todo fix this test to match current function
 describe('selection composed selectors', () => {
+  describe('getNewHiddenAgents', () => {
+    it('it has each agent from uidisplaydata in visibility map and nothing else', () => {
+      const payload = getNewHiddenAgents('agent1', mockVisibilitySelectionMap);
+      mockUIDisplayData.forEach(({ name }) => {
+        expect(payload).toHaveProperty(name);
+      });
+      expect(Object.keys(payload)).toHaveLength(mockUIDisplayData.length);
+    });
+    it('it adds provided agent to value array if array was previously empty', () => {
+      const payload = getNewHiddenAgents('agent3', mockVisibilitySelectionMap);
+      expect(payload).toEqual({
+        agent1: ['agent1'],
+        agent2: ['agent2'],
+        agent3: ['agent3'],
+      });
+    });
+    it('it removes agent name from value array if name was previously in array', () => {
+      const payload = getNewHiddenAgents('agent1', mockVisibilitySelectionMap);
+      expect(payload).toEqual({
+        agent1: [],
+        agent2: ['agent2'],
+        agent3: [],
+      });
+    });
+  });
+
   describe('getSelectionStateInfo', () => {
     it('returns an array of SelectionEntry objects', () => {
       const payload = getSelectionStateInfo(mockVisibilitySelectionMap);
@@ -46,11 +92,11 @@ describe('selection composed selectors', () => {
       expect(payload).toEqual([
         {
           name: 'agent1',
-          tags: ['state1'],
+          tags: ['agent1'],
         },
         {
           name: 'agent2',
-          tags: ['state1', 'state2'],
+          tags: ['agent2'],
         },
         {
           name: 'agent3',

--- a/src/components/AgentRow.tsx
+++ b/src/components/AgentRow.tsx
@@ -46,6 +46,7 @@ const AgentRow: React.FC<AgentRowProps> = (
         placement="right"
         title={hiddenStateTooltipText[checkedState]}
         color={TOOLTIP_COLOR}
+        trigger=["hover", "focus"]
       >
         <Checkbox
           checked={checkedState === CheckboxState.Checked}

--- a/src/components/AgentRow.tsx
+++ b/src/components/AgentRow.tsx
@@ -46,7 +46,7 @@ const AgentRow: React.FC<AgentRowProps> = (
         placement="right"
         title={hiddenStateTooltipText[checkedState]}
         color={TOOLTIP_COLOR}
-        trigger=["hover", "focus"]
+        trigger={['hover', 'focus']}
       >
         <Checkbox
           checked={checkedState === CheckboxState.Checked}

--- a/src/components/AgentRow.tsx
+++ b/src/components/AgentRow.tsx
@@ -5,12 +5,12 @@ import { UIDisplayEntry } from '@aics/simularium-viewer/type-declarations/simula
 import { TOOLTIP_COLOR, CheckboxState } from '../constants';
 import { VisibilityContext } from '../AgentVisibilityContext';
 
-interface CheckboxRowProps {
+interface AgentRowProps {
   agent: UIDisplayEntry;
 }
 
-const CheckboxRow: React.FC<CheckboxRowProps> = (
-  props: CheckboxRowProps
+const AgentRow: React.FC<AgentRowProps> = (
+  props: AgentRowProps
 ): JSX.Element => {
   const { agent } = props;
 
@@ -57,4 +57,4 @@ const CheckboxRow: React.FC<CheckboxRowProps> = (
   );
 };
 
-export default CheckboxRow;
+export default AgentRow;

--- a/src/components/CheckboxRow.tsx
+++ b/src/components/CheckboxRow.tsx
@@ -1,0 +1,60 @@
+import React, { useContext } from 'react';
+import { Checkbox, Tooltip } from 'antd';
+import { UIDisplayEntry } from '@aics/simularium-viewer/type-declarations/simularium/SelectionInterface';
+
+import { TOOLTIP_COLOR, CheckboxState } from '../constants';
+import { VisibilityContext } from '../AgentVisibilityContext';
+
+interface CheckboxRowProps {
+  agent: UIDisplayEntry;
+}
+
+const CheckboxRow: React.FC<CheckboxRowProps> = (
+  props: CheckboxRowProps
+): JSX.Element => {
+  const { agent } = props;
+
+  const { handleAgentCheckboxChange, hiddenAgents } =
+    useContext(VisibilityContext);
+
+  const getCheckboxState = () => {
+    if (hiddenAgents[agent.name]?.length === 0) {
+      return CheckboxState.Unchecked;
+    }
+    return CheckboxState.Checked;
+  };
+
+  const checkedState = getCheckboxState();
+
+  const hiddenStateTooltipText = {
+    [CheckboxState.Checked]: 'Hide',
+    [CheckboxState.Unchecked]: 'Show',
+    [CheckboxState.Indeterminate]: '',
+  };
+
+  return (
+    <div className="item-row" style={{ display: 'flex' }}>
+      <div
+        className="color-swatch"
+        style={{
+          backgroundColor: agent.color,
+          width: '12px',
+          height: '12px',
+        }}
+      ></div>
+      <Tooltip
+        placement="right"
+        title={hiddenStateTooltipText[checkedState]}
+        color={TOOLTIP_COLOR}
+      >
+        <Checkbox
+          checked={checkedState === CheckboxState.Checked}
+          onClick={() => handleAgentCheckboxChange(agent.name)}
+        />
+      </Tooltip>
+      <span>{agent.name}</span>
+    </div>
+  );
+};
+
+export default CheckboxRow;

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -5,13 +5,15 @@ import classNames from 'classnames';
 
 import { CheckboxState, TOOLTIP_COLOR } from '../constants';
 import { VisibilityContext } from '../AgentVisibilityContext';
+import CheckBoxRow from './CheckboxRow';
 
 import '../../css/side_panel.css';
 
-const SidePanel: React.FunctionComponent = (): JSX.Element => {
+const SidePanel: React.FC = (): JSX.Element => {
   const {
     handleAllAgentsCheckboxChange,
     hiddenAgents,
+    uiDisplayData,
     allAgentsHidden,
     noAgentsHidden,
   } = useContext(VisibilityContext);
@@ -26,7 +28,7 @@ const SidePanel: React.FunctionComponent = (): JSX.Element => {
     return CheckboxState.Indeterminate;
   };
 
-  const checkboxStatus = getCheckboxState();
+  const checkboxState = getCheckboxState();
 
   const tooltipText = {
     [CheckboxState.Unchecked]: 'Show',
@@ -41,16 +43,20 @@ const SidePanel: React.FunctionComponent = (): JSX.Element => {
         <div className="item-row">
           <Tooltip
             placement="right"
-            title={tooltipText[checkboxStatus]}
+            title={tooltipText[checkboxState]}
             color={TOOLTIP_COLOR}
           >
             <Checkbox
               className={classNames('checkbox', 'check-all')}
-              checked={checkboxStatus === CheckboxState.Checked}
-              onClick={() => handleAllAgentsCheckboxChange(checkboxStatus)}
+              indeterminate={checkboxState === CheckboxState.Indeterminate}
+              checked={checkboxState === CheckboxState.Checked}
+              onClick={() => handleAllAgentsCheckboxChange(checkboxState)}
             />
           </Tooltip>
           <span>All agent types</span>
+          {uiDisplayData.map((agent) => (
+            <CheckBoxRow key={agent.name} agent={agent} />
+          ))}
         </div>
       </div>
     </div>

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 
 import { CheckboxState, TOOLTIP_COLOR } from '../constants';
 import { VisibilityContext } from '../AgentVisibilityContext';
-import CheckBoxRow from './CheckboxRow';
+import AgentRow from './AgentRow';
 
 import '../../css/side_panel.css';
 
@@ -55,7 +55,7 @@ const SidePanel: React.FC = (): JSX.Element => {
           </Tooltip>
           <span>All agent types</span>
           {uiDisplayData.map((agent) => (
-            <CheckBoxRow key={agent.name} agent={agent} />
+            <AgentRow key={agent.name} agent={agent} />
           ))}
         </div>
       </div>

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -1,6 +1,19 @@
 import { SelectionEntry } from '@aics/simularium-viewer';
 import { VisibilitySelectionMap } from './constants';
 
+export const getNewHiddenAgents = (
+  agentName: string,
+  hiddenAgents: VisibilitySelectionMap
+): VisibilitySelectionMap => {
+  const newHidden: VisibilitySelectionMap = { ...hiddenAgents };
+  if (hiddenAgents[agentName].length === 0) {
+    newHidden[agentName] = [agentName];
+  } else {
+    newHidden[agentName] = [];
+  }
+  return newHidden;
+};
+
 export const getSelectionStateInfo = (
   currentVisibilityMap: VisibilitySelectionMap
 ): SelectionEntry[] => {


### PR DESCRIPTION
Time Estimate or Size
=======
_Small, 10 minutes_
Please review for function only, inline styling used is temporary.

Problem
=======
Continuing work on selection in NBSV. 

Solution
========
We now render a row for each agent that contains a name, color swatch, and a checkbox to hide the agent.

Selector `getNewHiddenAgents` provides the value for the agent-specific handler, tests are added for the selector.


* New feature (non-breaking change which adds functionality)
* This change requires updated or new tests

Steps to Verify:
----------------
1. Each agent checkbox should hide the agent and be unchecked while agent is hidden.
2. If some but not agents are hidden the hide-all checkbox should be indeterminate (blue square).
3. Hiding/showing all agents should reflect in viewer and in agent specific checkboxes.

