### PR TITLE
Feature/child rows

### DIFF
--- a/src/AgentVisibilityContext.tsx
+++ b/src/AgentVisibilityContext.tsx
@@ -41,9 +41,8 @@ export const VisibilityProvider = ({ children }: { children: ReactNode }) => {
 
   const receiveUIDisplayData = (data: UIDisplayData) => {
     setUiDisplayData(data);
-    const initialSelections = getInitialUserSelections(data);
-    setHighlightedAgents(initialSelections);
-    setHiddenAgents(initialSelections);
+    setHighlightedAgents(getInitialUserSelections(data));
+    setHiddenAgents(getInitialUserSelections(data));
   };
 
   const handleHideCheckboxChange = (name: string, children: string[]) => {

--- a/src/AgentVisibilityContext.tsx
+++ b/src/AgentVisibilityContext.tsx
@@ -3,7 +3,7 @@ import { UIDisplayData } from '@aics/simularium-viewer';
 
 import { UserChangesMap } from './constants';
 import {
-  getInitialUserSelections,
+  makeEmptyUserSelections,
   updateUserChangesAfterCheckboxClick,
   getSelectionAfterChildCheckboxClick,
 } from './utils';
@@ -41,8 +41,8 @@ export const VisibilityProvider = ({ children }: { children: ReactNode }) => {
 
   const receiveUIDisplayData = (data: UIDisplayData) => {
     setUiDisplayData(data);
-    setHighlightedAgents(getInitialUserSelections(data));
-    setHiddenAgents(getInitialUserSelections(data));
+    setHighlightedAgents(makeEmptyUserSelections(data));
+    setHiddenAgents(makeEmptyUserSelections(data));
   };
 
   const handleHideCheckboxChange = (name: string, children: string[]) => {

--- a/src/AgentVisibilityContext.tsx
+++ b/src/AgentVisibilityContext.tsx
@@ -3,7 +3,7 @@ import { UIDisplayData } from '@aics/simularium-viewer';
 
 import { UserChangesMap } from './constants';
 import {
-  mapUIDisplayDataToSelectionMap,
+  getInitialUserSelections,
   updateUserChangesAfterCheckboxClick,
   getSelectionAfterChildCheckboxClick,
 } from './utils';
@@ -41,9 +41,9 @@ export const VisibilityProvider = ({ children }: { children: ReactNode }) => {
 
   const receiveUIDisplayData = (data: UIDisplayData) => {
     setUiDisplayData(data);
-    const noAgentsSelectedMap = mapUIDisplayDataToSelectionMap(data);
-    setHighlightedAgents(noAgentsSelectedMap);
-    setHiddenAgents(noAgentsSelectedMap);
+    const initialSelections = getInitialUserSelections(data);
+    setHighlightedAgents(initialSelections);
+    setHiddenAgents(initialSelections);
   };
 
   const handleHideCheckboxChange = (name: string, children: string[]) => {

--- a/src/AgentVisibilityContext.tsx
+++ b/src/AgentVisibilityContext.tsx
@@ -3,7 +3,7 @@ import { UIDisplayData } from '@aics/simularium-viewer';
 
 import { VisibilitySelectionMap } from './constants';
 import {
-  getNewMapAfterDisplayStateClick,
+  getNewMapAfterChildAgentClick,
   mapUIDisplayDataToSelectionMap,
   getNewMapAfterTopLevelCheckboxClick,
 } from './utils';
@@ -16,11 +16,11 @@ interface VisibilityContextType {
   setHiddenAgents: React.Dispatch<React.SetStateAction<VisibilitySelectionMap>>;
   handleVisibilityCheckboxChange: (
     agentName: string,
-    displayStateName?: string
+    childAgentName?: string
   ) => void;
   handleHightlightCheckboxChange: (
     agentName: string,
-    displayStateName?: string
+    childAgentName?: string
   ) => void;
 }
 
@@ -47,7 +47,7 @@ export const VisibilityProvider = ({ children }: { children: ReactNode }) => {
     setHiddenAgents(noAgentsSelectedMap);
   };
 
-  const getDisplayStates = (agentName: string): string[] => {
+  const getChildren = (agentName: string): string[] => {
     const agentEntry = uiDisplayData.find((entry) => entry.name === agentName);
     if (agentEntry === undefined) {
       return [];
@@ -57,15 +57,15 @@ export const VisibilityProvider = ({ children }: { children: ReactNode }) => {
 
   const handleVisibilityCheckboxChange = (
     agentName: string,
-    displayStateName?: string
+    childAgentName?: string
   ) => {
-    if (displayStateName !== undefined) {
-      const displayStates = getDisplayStates(agentName);
+    if (childAgentName !== undefined) {
+      const children = getChildren(agentName);
       setHiddenAgents((prevHiddenAgents) =>
-        getNewMapAfterDisplayStateClick(
+        getNewMapAfterChildAgentClick(
           agentName,
-          displayStateName,
-          displayStates,
+          childAgentName,
+          children,
           prevHiddenAgents
         )
       );
@@ -78,15 +78,15 @@ export const VisibilityProvider = ({ children }: { children: ReactNode }) => {
 
   const handleHightlightCheckboxChange = (
     agentName: string,
-    displayStateName?: string
+    childAgentName?: string
   ) => {
-    if (displayStateName !== undefined) {
-      const displayStates = getDisplayStates(agentName);
+    if (childAgentName !== undefined) {
+      const children = getChildren(agentName);
       setHighlightedAgents((prevHiddenAgents) =>
-        getNewMapAfterDisplayStateClick(
+        getNewMapAfterChildAgentClick(
           agentName,
-          displayStateName,
-          displayStates,
+          childAgentName,
+          children,
           prevHiddenAgents
         )
       );

--- a/src/AgentVisibilityContext.tsx
+++ b/src/AgentVisibilityContext.tsx
@@ -1,27 +1,23 @@
 import React, { createContext, useState, ReactNode } from 'react';
 import { UIDisplayData } from '@aics/simularium-viewer';
 
-import { VisibilitySelectionMap } from './constants';
+import { UserChangesMap } from './constants';
 import {
-  getNewMapAfterChildAgentClick,
   mapUIDisplayDataToSelectionMap,
-  getNewMapAfterTopLevelCheckboxClick,
+  getSelectionAfterCheckboxClick,
+  getSelectionAfterChildCheckboxClick,
 } from './utils';
 
 interface VisibilityContextType {
   uiDisplayData: UIDisplayData;
-  hiddenAgents: VisibilitySelectionMap;
-  highlightedAgents: VisibilitySelectionMap;
+  hiddenAgents: UserChangesMap;
+  highlightedAgents: UserChangesMap;
   receiveUIDisplayData: (data: UIDisplayData) => void;
-  setHiddenAgents: React.Dispatch<React.SetStateAction<VisibilitySelectionMap>>;
-  handleVisibilityCheckboxChange: (
-    agentName: string,
-    childAgentName?: string
-  ) => void;
-  handleHightlightCheckboxChange: (
-    agentName: string,
-    childAgentName?: string
-  ) => void;
+  setHiddenAgents: React.Dispatch<React.SetStateAction<UserChangesMap>>;
+  handleHideCheckboxChange: (name: string, children: string[]) => void;
+  handleHideChildCheckboxChange: (name: string, parent: string) => void;
+  handleHighlightChange: (name: string, children: string[]) => void;
+  handleChildHighlightChange: (name: string, parent: string) => void;
 }
 
 export const VisibilityContext = createContext<VisibilityContextType>({
@@ -30,15 +26,18 @@ export const VisibilityContext = createContext<VisibilityContextType>({
   highlightedAgents: {},
   receiveUIDisplayData: () => {},
   setHiddenAgents: () => {},
-  handleVisibilityCheckboxChange: () => {},
-  handleHightlightCheckboxChange: () => {},
+  handleHideCheckboxChange: () => {},
+  handleHideChildCheckboxChange: () => {},
+  handleHighlightChange: () => {},
+  handleChildHighlightChange: () => {},
 });
 
 export const VisibilityProvider = ({ children }: { children: ReactNode }) => {
   const [uiDisplayData, setUiDisplayData] = useState<UIDisplayData>([]);
-  const [hiddenAgents, setHiddenAgents] = useState<VisibilitySelectionMap>({});
-  const [highlightedAgents, setHighlightedAgents] =
-    useState<VisibilitySelectionMap>({});
+  const [hiddenAgents, setHiddenAgents] = useState<UserChangesMap>({});
+  const [highlightedAgents, setHighlightedAgents] = useState<UserChangesMap>(
+    {}
+  );
 
   const receiveUIDisplayData = (data: UIDisplayData) => {
     setUiDisplayData(data);
@@ -47,54 +46,28 @@ export const VisibilityProvider = ({ children }: { children: ReactNode }) => {
     setHiddenAgents(noAgentsSelectedMap);
   };
 
-  const getChildren = (agentName: string): string[] => {
-    const agentEntry = uiDisplayData.find((entry) => entry.name === agentName);
-    if (agentEntry === undefined) {
-      return [];
-    }
-    return agentEntry.displayStates.map((state) => state.name);
+  const handleHideCheckboxChange = (name: string, children: string[]) => {
+    setHiddenAgents((prevHiddenAgents) =>
+      getSelectionAfterCheckboxClick(name, children, prevHiddenAgents)
+    );
   };
 
-  const handleVisibilityCheckboxChange = (
-    agentName: string,
-    childAgentName?: string
-  ) => {
-    if (childAgentName !== undefined) {
-      const children = getChildren(agentName);
-      setHiddenAgents((prevHiddenAgents) =>
-        getNewMapAfterChildAgentClick(
-          agentName,
-          childAgentName,
-          children,
-          prevHiddenAgents
-        )
-      );
-    } else {
-      setHiddenAgents((prevHiddenAgents) =>
-        getNewMapAfterTopLevelCheckboxClick(agentName, prevHiddenAgents)
-      );
-    }
+  const handleHideChildCheckboxChange = (name: string, parent: string) => {
+    setHiddenAgents((prevHiddenAgents) =>
+      getSelectionAfterChildCheckboxClick(name, parent, prevHiddenAgents)
+    );
   };
 
-  const handleHightlightCheckboxChange = (
-    agentName: string,
-    childAgentName?: string
-  ) => {
-    if (childAgentName !== undefined) {
-      const children = getChildren(agentName);
-      setHighlightedAgents((prevHiddenAgents) =>
-        getNewMapAfterChildAgentClick(
-          agentName,
-          childAgentName,
-          children,
-          prevHiddenAgents
-        )
-      );
-    } else {
-      setHighlightedAgents((prevHiddenAgents) =>
-        getNewMapAfterTopLevelCheckboxClick(agentName, prevHiddenAgents)
-      );
-    }
+  const handleHighlightChange = (name: string, children: string[]) => {
+    setHighlightedAgents((prevHighlightedAgents) =>
+      getSelectionAfterCheckboxClick(name, children, prevHighlightedAgents)
+    );
+  };
+
+  const handleChildHighlightChange = (name: string, parent: string) => {
+    setHighlightedAgents((prevHighlightedAgents) =>
+      getSelectionAfterChildCheckboxClick(name, parent, prevHighlightedAgents)
+    );
   };
 
   const vis = {
@@ -103,8 +76,10 @@ export const VisibilityProvider = ({ children }: { children: ReactNode }) => {
     highlightedAgents,
     receiveUIDisplayData,
     setHiddenAgents,
-    handleHightlightCheckboxChange,
-    handleVisibilityCheckboxChange,
+    handleHighlightChange,
+    handleChildHighlightChange,
+    handleHideCheckboxChange,
+    handleHideChildCheckboxChange,
   };
 
   return (

--- a/src/AgentVisibilityContext.tsx
+++ b/src/AgentVisibilityContext.tsx
@@ -4,7 +4,7 @@ import { UIDisplayData } from '@aics/simularium-viewer';
 import { UserChangesMap } from './constants';
 import {
   mapUIDisplayDataToSelectionMap,
-  getSelectionAfterCheckboxClick,
+  updateUserChangesAfterCheckboxClick,
   getSelectionAfterChildCheckboxClick,
 } from './utils';
 
@@ -48,7 +48,7 @@ export const VisibilityProvider = ({ children }: { children: ReactNode }) => {
 
   const handleHideCheckboxChange = (name: string, children: string[]) => {
     setHiddenAgents((prevHiddenAgents) =>
-      getSelectionAfterCheckboxClick(name, children, prevHiddenAgents)
+      updateUserChangesAfterCheckboxClick(name, children, prevHiddenAgents)
     );
   };
 
@@ -60,7 +60,7 @@ export const VisibilityProvider = ({ children }: { children: ReactNode }) => {
 
   const handleHighlightChange = (name: string, children: string[]) => {
     setHighlightedAgents((prevHighlightedAgents) =>
-      getSelectionAfterCheckboxClick(name, children, prevHighlightedAgents)
+      updateUserChangesAfterCheckboxClick(name, children, prevHighlightedAgents)
     );
   };
 

--- a/src/AgentVisibilityContext.tsx
+++ b/src/AgentVisibilityContext.tsx
@@ -2,7 +2,11 @@ import React, { createContext, useState, ReactNode } from 'react';
 import { UIDisplayData } from '@aics/simularium-viewer';
 
 import { VisibilitySelectionMap } from './constants';
-import { getNewSelectionMap, mapUIDisplayDataToSelectionMap } from './utils';
+import {
+  getNewMapAfterDisplayStateClick,
+  mapUIDisplayDataToSelectionMap,
+  getNewMapAfterTopLevelCheckboxClick,
+} from './utils';
 
 interface VisibilityContextType {
   uiDisplayData: UIDisplayData;
@@ -10,8 +14,14 @@ interface VisibilityContextType {
   highlightedAgents: VisibilitySelectionMap;
   receiveUIDisplayData: (data: UIDisplayData) => void;
   setHiddenAgents: React.Dispatch<React.SetStateAction<VisibilitySelectionMap>>;
-  handleVisibilityCheckboxChange: (agentName: string) => void;
-  handleHightlightCheckboxChange: (agentName: string) => void;
+  handleVisibilityCheckboxChange: (
+    agentName: string,
+    displayStateName?: string
+  ) => void;
+  handleHightlightCheckboxChange: (
+    agentName: string,
+    displayStateName?: string
+  ) => void;
 }
 
 export const VisibilityContext = createContext<VisibilityContextType>({
@@ -37,16 +47,54 @@ export const VisibilityProvider = ({ children }: { children: ReactNode }) => {
     setHiddenAgents(noAgentsSelectedMap);
   };
 
-  const handleVisibilityCheckboxChange = (agentName: string) => {
-    setHiddenAgents((prevHiddenAgents) =>
-      getNewSelectionMap(agentName, prevHiddenAgents)
-    );
+  const getDisplayStates = (agentName: string): string[] => {
+    const agentEntry = uiDisplayData.find((entry) => entry.name === agentName);
+    if (agentEntry === undefined) {
+      return [];
+    }
+    return agentEntry.displayStates.map((state) => state.name);
   };
 
-  const handleHightlightCheckboxChange = (agentName: string) => {
-    setHighlightedAgents((prevHighlightedAgents) =>
-      getNewSelectionMap(agentName, prevHighlightedAgents)
-    );
+  const handleVisibilityCheckboxChange = (
+    agentName: string,
+    displayStateName?: string
+  ) => {
+    if (displayStateName !== undefined) {
+      const displayStates = getDisplayStates(agentName);
+      setHiddenAgents((prevHiddenAgents) =>
+        getNewMapAfterDisplayStateClick(
+          agentName,
+          displayStateName,
+          displayStates,
+          prevHiddenAgents
+        )
+      );
+    } else {
+      setHiddenAgents((prevHiddenAgents) =>
+        getNewMapAfterTopLevelCheckboxClick(agentName, prevHiddenAgents)
+      );
+    }
+  };
+
+  const handleHightlightCheckboxChange = (
+    agentName: string,
+    displayStateName?: string
+  ) => {
+    if (displayStateName !== undefined) {
+      const displayStates = getDisplayStates(agentName);
+      setHighlightedAgents((prevHiddenAgents) =>
+        getNewMapAfterDisplayStateClick(
+          agentName,
+          displayStateName,
+          displayStates,
+          prevHiddenAgents
+        )
+      );
+    } else {
+      setHighlightedAgents((prevHiddenAgents) =>
+        getNewMapAfterTopLevelCheckboxClick(agentName, prevHiddenAgents)
+      );
+    }
   };
 
   const vis = {

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -45,8 +45,12 @@ const initialPlaybackData: PlaybackData = {
 
 function ViewerWidget(props: ViewerProps): JSX.Element {
   const controller = props.controller;
-  const { hiddenAgents, highlightedAgents, receiveUIDisplayData } =
-    useContext(VisibilityContext);
+  const {
+    hiddenAgents,
+    highlightedAgents,
+    receiveUIDisplayData,
+    uiDisplayData,
+  } = useContext(VisibilityContext);
 
   // Trajectory data
   const [modelInfo, setModelInfo] = useState<ModelInfo | undefined>({});
@@ -157,9 +161,14 @@ function ViewerWidget(props: ViewerProps): JSX.Element {
           showCameraControls={false}
           onTrajectoryFileInfoChanged={handleTrajectoryData}
           selectionStateInfo={{
-            hiddenAgents: convertMapToSelectionStateInfo(hiddenAgents),
-            highlightedAgents:
-              convertMapToSelectionStateInfo(highlightedAgents),
+            hiddenAgents: convertMapToSelectionStateInfo(
+              hiddenAgents,
+              uiDisplayData
+            ),
+            highlightedAgents: convertMapToSelectionStateInfo(
+              highlightedAgents,
+              uiDisplayData
+            ),
             colorChange: null,
           }}
           onUIDisplayDataChanged={receiveUIDisplayData}

--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -9,60 +9,65 @@ import {
 describe('utils for converting selection data types and handling selection actions', () => {
   describe('updateUserChangesAfterCheckboxClick', () => {
     it('removes an agent with no children from selection if it was previously included', () => {
+      const prevState = {
+        agent_with_no_children: ['agent_with_no_children'],
+      };
       const result = updateUserChangesAfterCheckboxClick(
         'agent_with_no_children',
         [],
-        {
-          agent_with_no_children: ['agent_with_no_children'],
-        }
+        prevState
       );
       expect(result).toEqual({ agent_with_no_children: [] });
     });
     it('it adds an agent with no children to selection if it was was not previously included in selection', () => {
+      const prevState = {
+        agent_with_no_children: [],
+      };
       const result = updateUserChangesAfterCheckboxClick(
         'agent_with_no_children',
         [],
-        {
-          agent_with_no_children: [],
-        }
+        prevState
       );
       expect(result).toEqual({
         agent_with_no_children: ['agent_with_no_children'],
       });
     });
     it('removes an agents children from selection if they were previously selected', () => {
+      const prevState = {
+        agent_with_children: ['child1', 'child2'],
+      };
       const result = updateUserChangesAfterCheckboxClick(
         'agent_with_children',
         ['child1', 'child2'],
-        {
-          agent_with_children: ['child1', 'child2'],
-        }
+        prevState,
       );
       expect(result).toEqual({
         agent_with_children: [],
       });
     });
-    it('selects agents children if they were not previously selected', () => {
+    it('adds agents children to the array if they were not previously selected', () => {
+      const prevState = {
+        agent_with_children: [],
+      };
       const childList = ['child1', 'child2'];
       const result = updateUserChangesAfterCheckboxClick(
         'agent_with_children',
         childList,
-        {
-          agent_with_children: [],
-        }
+        prevState
       );
       expect(result).toEqual({
         agent_with_children: childList,
       });
     });
     it('it includes all children in selection if only some were previously selected', () => {
+      const prevState = {
+        agent_with_children: ['child1'],
+      };
       const childList = ['child1', 'child2'];
       const result = updateUserChangesAfterCheckboxClick(
         'agent_with_children',
         childList,
-        {
-          agent_with_children: ['child1'],
-        }
+        prevState
       );
       expect(result).toEqual({
         agent_with_children: childList,
@@ -72,15 +77,25 @@ describe('utils for converting selection data types and handling selection actio
 
   describe('getSelectionAfterChildCheckboxClick', () => {
     it('removes child from parents selection array if it was previously included', () => {
-      const result = getSelectionAfterChildCheckboxClick('child', 'parent', {
+      const prevState = {
         parent: ['child'],
-      });
+      };
+      const result = getSelectionAfterChildCheckboxClick(
+        'child',
+        'parent',
+        prevState
+      );
       expect(result).toEqual({ parent: [] });
     });
     it('adds child to parents selection array if child was not previously included', () => {
-      const result = getSelectionAfterChildCheckboxClick('child', 'parent', {
+      const prevState = {
         parent: ['child2'],
-      });
+      };
+      const result = getSelectionAfterChildCheckboxClick(
+        'child',
+        'parent',
+        prevState
+      );
       expect(result).toEqual({ parent: ['child2', 'child'] });
     });
     it('will throw an error if the parent is not found in the userChangesMap', () => {

--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -112,7 +112,7 @@ describe('utils for converting selection data types and handling selection actio
   });
 
   describe('convertMapToSelectionStateInfo', () => {
-    it('should return a selection entry with an empty tags array if agent name is in user changes map has agent name in array', () => {
+    it('should return a selection entry with an empty tags array if agent name is in user changes map and has agent name in array', () => {
       const agent = {
         name: 'agent_no_children',
         displayStates: [],

--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -8,7 +8,7 @@ import {
 
 describe('utils for converting selection data types and handling selection actions', () => {
   describe('updateUserChangesAfterCheckboxClick', () => {
-    it('removes an agent with no children from selection if it was previoulsy included', () => {
+    it('removes an agent with no children from selection if it was previously included', () => {
       const result = updateUserChangesAfterCheckboxClick(
         'agent_with_no_children',
         [],

--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -1,7 +1,7 @@
 import { UIDisplayData } from '@aics/simularium-viewer';
 import {
   convertMapToSelectionStateInfo,
-  getNewMapAfterDisplayStateClick,
+  getNewMapAfterChildAgentClick,
   getNewMapAfterTopLevelCheckboxClick,
 } from '../utils';
 
@@ -95,7 +95,7 @@ describe('utils for converting selection data types and handling selection actio
         agent5: ['state1'],
       });
     });
-        it('it removes displaystates and replaces them with empty array', () => {
+        it('it removes children and replaces them with empty array', () => {
           const payload = getNewMapAfterTopLevelCheckboxClick(
             'agent4',
             mockVisibilitySelectionMap
@@ -110,9 +110,9 @@ describe('utils for converting selection data types and handling selection actio
         });
   });
 
-  describe('getNewMapAfterDisplayStateClick', () => {
-    it('if selection array is empty, it fills its with all display states except the one that was clicked', () => {
-      const payload = getNewMapAfterDisplayStateClick(
+  describe('getNewMapAfterChildAgentClick', () => {
+    it('if selection array is empty, it fills its with all children except the one that was clicked', () => {
+      const payload = getNewMapAfterChildAgentClick(
         'agent3',
         'state1',
         ['state1', 'state2', 'state3'],
@@ -126,8 +126,8 @@ describe('utils for converting selection data types and handling selection actio
         agent5: ['state1'],
       });
     });
-    it('if display state is selected among other display states, it should be removed from selection array', () => {
-      const payload = getNewMapAfterDisplayStateClick(
+    it('if child is selected among other children, it should be removed from selection array', () => {
+      const payload = getNewMapAfterChildAgentClick(
         'agent4',
         'state1',
         ['state1', 'state2', 'state3'],
@@ -141,8 +141,8 @@ describe('utils for converting selection data types and handling selection actio
         agent5: ['state1'],
       });
     });
-    it('if clicked display state is the only current selection, it should return an array with the agent name', () => {
-      const payload = getNewMapAfterDisplayStateClick(
+    it('if clicked child is the only current selection, it should return an array with the agent name', () => {
+      const payload = getNewMapAfterChildAgentClick(
         'agent5',
         'state1',
         ['state1', 'state2', 'state3'],
@@ -156,8 +156,8 @@ describe('utils for converting selection data types and handling selection actio
         agent5: ['agent5'],
       });
     });
-    it('if display state is clicked and selection array currently has agent name, replace it with display state name', () => {
-      const payload = getNewMapAfterDisplayStateClick(
+    it('if child is clicked and selection array currently has agent name, replace it with child name', () => {
+      const payload = getNewMapAfterChildAgentClick(
         'agent1',
         'state1',
         ['state1', 'state2', 'state3'],
@@ -171,8 +171,8 @@ describe('utils for converting selection data types and handling selection actio
         agent5: ['state1'],
       });
     });
-    it('if adding clicked display state means all display states are selected, make selection array empty', () => {
-      const payload = getNewMapAfterDisplayStateClick(
+    it('if adding clicked child means all children are selected, make selection array empty', () => {
+      const payload = getNewMapAfterChildAgentClick(
         'agent4',
         'state3',
         ['state1', 'state2', 'state3'],
@@ -186,8 +186,8 @@ describe('utils for converting selection data types and handling selection actio
         agent5: ['state1'],
       });
     });
-    it('if adding clicked display state is leaves at least one display state unselected, add clicked state to array', () => {
-      const payload = getNewMapAfterDisplayStateClick(
+    it('if adding clicked child is leaves at least one child unselected, add clicked state to array', () => {
+      const payload = getNewMapAfterChildAgentClick(
         'agent5',
         'state2',
         ['state1', 'state2', 'state3'],

--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -3,7 +3,7 @@ import {
   getSelectionAfterChildCheckboxClick,
   updateUserChangesAfterCheckboxClick,
   getChildren,
-  mapUIDisplayDataToSelectionMap,
+  getInitialUserSelections,
 } from '../utils';
 
 describe('utils for converting selection data types and handling selection actions', () => {
@@ -166,7 +166,7 @@ describe('utils for converting selection data types and handling selection actio
       expect(result).toEqual([]);
     });
   });
-  describe('mapUIDisplayDataToSelectionMap', () => {
+  describe('getInitialUserSelections', () => {
     it('should make an entry for each agent with an empty array as its value', () => {
       const uiData = [
         {
@@ -175,7 +175,7 @@ describe('utils for converting selection data types and handling selection actio
           color: '#000000',
         },
       ];
-      const result = mapUIDisplayDataToSelectionMap(uiData);
+      const result = getInitialUserSelections(uiData);
       expect(result).toEqual({
         agent_with_no_children: [],
       });

--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -3,7 +3,7 @@ import {
   getSelectionAfterChildCheckboxClick,
   updateUserChangesAfterCheckboxClick,
   getChildren,
-  getInitialUserSelections,
+  makeEmptyUserSelections,
 } from '../utils';
 
 describe('utils for converting selection data types and handling selection actions', () => {
@@ -166,7 +166,7 @@ describe('utils for converting selection data types and handling selection actio
       expect(result).toEqual([]);
     });
   });
-  describe('getInitialUserSelections', () => {
+  describe('makeEmptyUserSelections', () => {
     it('should make an entry for each agent with an empty array as its value', () => {
       const uiData = [
         {
@@ -175,7 +175,7 @@ describe('utils for converting selection data types and handling selection actio
           color: '#000000',
         },
       ];
-      const result = getInitialUserSelections(uiData);
+      const result = makeEmptyUserSelections(uiData);
       expect(result).toEqual({
         agent_with_no_children: [],
       });

--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -1,4 +1,3 @@
-// import { UIDisplayData } from '@aics/simularium-viewer';
 import {
   convertMapToSelectionStateInfo,
   getSelectionAfterChildCheckboxClick,
@@ -113,18 +112,7 @@ describe('utils for converting selection data types and handling selection actio
   });
 
   describe('convertMapToSelectionStateInfo', () => {
-    it('should put the agent name in the tags field of the selection entry of an agent with no display states whose userChangesMap value is empty', () => {
-      const agent = {
-        name: 'agent_no_children',
-        displayStates: [],
-        color: '#000000',
-      };
-      const result = convertMapToSelectionStateInfo({ agent_no_children: [] }, [
-        agent,
-      ]);
-      expect(result).toEqual([{ name: 'agent_no_children', tags: [] }]);
-    });
-    it('should return no selection entry if the agent has no display states and the agent name is in the userChangesMap', () => {
+    it('should return a selection entry with an empty tags array if agent name is in user changes map has agent name in array', () => {
       const agent = {
         name: 'agent_no_children',
         displayStates: [],
@@ -134,42 +122,52 @@ describe('utils for converting selection data types and handling selection actio
         { agent_no_children: ['agent_no_children'] },
         [agent]
       );
+      expect(result).toEqual([{ name: 'agent_no_children', tags: [] }]);
+    });
+    it('should return no selection entry for an agent withtout children if the user changes map array is empty', () => {
+      const agent = {
+        name: 'agent_no_children',
+        displayStates: [],
+        color: '#000000',
+      };
+      const result = convertMapToSelectionStateInfo({ agent_no_children: [] }, [
+        agent,
+      ]);
+      expect(result).toEqual([]);
+    });
+    it('should include all the display states currently in the userChangesMap in the tags array of the selection entry', () => {
+      const agent = {
+        name: 'agent_with_children',
+        displayStates: [
+          { name: 'state1', id: '1', color: '#000000' },
+          { name: 'state2', id: '2', color: '#000000' },
+        ],
+        color: '#000000',
+      };
+      const result = convertMapToSelectionStateInfo(
+        { agent_with_children: ['1'] },
+        [agent]
+      );
+      expect(result).toEqual([{ name: 'agent_with_children', tags: ['1'] }]);
+    });
+    it('should return no selection entry if no display states are in the userChangesMap', () => {
+      const agent = {
+        name: 'agent_with_children',
+        displayStates: [
+          { name: 'state1', id: '1', color: '#000000' },
+          { name: 'state2', id: '2', color: '#000000' },
+        ],
+        color: '#000000',
+      };
+      const result = convertMapToSelectionStateInfo(
+        { agent_with_children: [] },
+        [agent]
+      );
       expect(result).toEqual([]);
     });
   });
-  it('should remove the display states selected in the userChangesMap from the tags field of an agents selection entry', () => {
-    const agent = {
-      name: 'agent_with_children',
-      displayStates: [
-        { name: 'state1', id: '1', color: '#000000' },
-        { name: 'state2', id: '2', color: '#000000' },
-      ],
-      color: '#000000',
-    };
-    const result = convertMapToSelectionStateInfo(
-      { agent_with_children: ['1'] },
-      [agent]
-    );
-    expect(result).toEqual([{ name: 'agent_with_children', tags: ['2'] }]);
-  });
-  it('should return no selection entry if all the display states are in the userChangesMap', () => {
-    const agent = {
-      name: 'agent_with_children',
-      displayStates: [
-        { name: 'state1', id: '1', color: '#000000' },
-        { name: 'state2', id: '2', color: '#000000' },
-      ],
-      color: '#000000',
-    };
-    const result = convertMapToSelectionStateInfo(
-      { agent_with_children: ['1', '2'] },
-      [agent]
-    );
-    expect(result).toEqual([]);
-  });
-
   describe('mapUIDisplayDataToSelectionMap', () => {
-    it('should make an agent entry with just agent name for ui entries with no display states', () => {
+    it('should make an entry for each agent with an empty array as its value', () => {
       const uiData = [
         {
           name: 'agent_with_no_children',
@@ -179,22 +177,8 @@ describe('utils for converting selection data types and handling selection actio
       ];
       const result = mapUIDisplayDataToSelectionMap(uiData);
       expect(result).toEqual({
-        agent_with_no_children: ['agent_with_no_children'],
+        agent_with_no_children: [],
       });
-    });
-    it('should make an agent entry with all the display state ids for ui entries with display states', () => {
-      const uiData = [
-        {
-          name: 'agent_with_children',
-          displayStates: [
-            { name: 'state1', id: '1', color: '#000000' },
-            { name: 'state2', id: '2', color: '#000000' },
-          ],
-          color: '#000000',
-        },
-      ];
-      const result = mapUIDisplayDataToSelectionMap(uiData);
-      expect(result).toEqual({ agent_with_children: ['1', '2'] });
     });
   });
 });

--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -124,7 +124,7 @@ describe('utils for converting selection data types and handling selection actio
       );
       expect(result).toEqual([{ name: 'agent_no_children', tags: [] }]);
     });
-    it('should return no selection entry for an agent withtout children if the user changes map array is empty', () => {
+    it('should return no selection entry for an agent without children if the user changes map array is empty', () => {
       const agent = {
         name: 'agent_no_children',
         displayStates: [],

--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -1,16 +1,26 @@
 import { UIDisplayData } from '@aics/simularium-viewer';
-import { getNewSelectionMap, convertMapToSelectionStateInfo } from '../utils';
+import {
+  convertMapToSelectionStateInfo,
+  getNewMapAfterDisplayStateClick,
+  getNewMapAfterTopLevelCheckboxClick,
+} from '../utils';
 
 const mockVisibilitySelectionMap = {
   agent1: ['agent1'],
   agent2: ['agent2'],
   agent3: [],
+  agent4: ['state1', 'state2'],
+  agent5: ['state1'],
 };
 
 const mockUIDisplayData: UIDisplayData = [
   {
     name: 'agent1',
-    displayStates: [],
+    displayStates: [
+      { name: 'state1', id: '1', color: '#000000' },
+      { name: 'state2', id: '2', color: '#000000' },
+      { name: 'state3', id: '3', color: '#000000' },
+    ],
     color: '#000000',
   },
   {
@@ -20,41 +30,185 @@ const mockUIDisplayData: UIDisplayData = [
   },
   {
     name: 'agent3',
-    displayStates: [],
+    displayStates: [
+      { name: 'state1', id: '1', color: '#000000' },
+      { name: 'state2', id: '2', color: '#000000' },
+      { name: 'state3', id: '3', color: '#000000' },
+    ],
+    color: '#000000',
+  },
+  {
+    name: 'agent4',
+    displayStates: [
+      { name: 'state1', id: '1', color: '#000000' },
+      { name: 'state2', id: '2', color: '#000000' },
+      { name: 'state3', id: '3', color: '#000000' },
+    ],
+    color: '#000000',
+  },
+  {
+    name: 'agent5',
+    displayStates: [
+      { name: 'state1', id: '1', color: '#000000' },
+      { name: 'state2', id: '2', color: '#000000' },
+      { name: 'state3', id: '3', color: '#000000' },
+    ],
     color: '#000000',
   },
 ];
 
 describe('utils for converting selection data types and handling selection actions', () => {
-  describe('getNewSelectionMap', () => {
+  describe('getNewMapAfterTopLevelCheckboxClick', () => {
     it('it has each agent from uidisplaydata in visibility map and nothing else', () => {
-      const payload = getNewSelectionMap('agent1', mockVisibilitySelectionMap);
+      const payload = getNewMapAfterTopLevelCheckboxClick(
+        'agent1',
+        mockVisibilitySelectionMap
+      );
       mockUIDisplayData.forEach(({ name }) => {
         expect(payload).toHaveProperty(name);
       });
       expect(Object.keys(payload)).toHaveLength(mockUIDisplayData.length);
     });
     it('it adds provided agent to value array if array was previously empty', () => {
-      const payload = getNewSelectionMap('agent3', mockVisibilitySelectionMap);
+      const payload = getNewMapAfterTopLevelCheckboxClick(
+        'agent3',
+        mockVisibilitySelectionMap
+      );
       expect(payload).toEqual({
         agent1: ['agent1'],
         agent2: ['agent2'],
         agent3: ['agent3'],
+        agent4: ['state1', 'state2'],
+        agent5: ['state1'],
       });
     });
     it('it removes agent name from value array if name was previously in array', () => {
-      const payload = getNewSelectionMap('agent1', mockVisibilitySelectionMap);
+      const payload = getNewMapAfterTopLevelCheckboxClick(
+        'agent1',
+        mockVisibilitySelectionMap
+      );
       expect(payload).toEqual({
         agent1: [],
         agent2: ['agent2'],
         agent3: [],
+        agent4: ['state1', 'state2'],
+        agent5: ['state1'],
+      });
+    });
+        it('it removes displaystates and replaces them with empty array', () => {
+          const payload = getNewMapAfterTopLevelCheckboxClick(
+            'agent4',
+            mockVisibilitySelectionMap
+          );
+          expect(payload).toEqual({
+            agent1: ['agent1'],
+            agent2: ['agent2'],
+            agent3: [],
+            agent4: ['agent4'],
+            agent5: ['state1'],
+          });
+        });
+  });
+
+  describe('getNewMapAfterDisplayStateClick', () => {
+    it('if selection array is empty, it fills its with all display states except the one that was clicked', () => {
+      const payload = getNewMapAfterDisplayStateClick(
+        'agent3',
+        'state1',
+        ['state1', 'state2', 'state3'],
+        mockVisibilitySelectionMap
+      );
+      expect(payload).toEqual({
+        agent1: ['agent1'],
+        agent2: ['agent2'],
+        agent3: ['state2', 'state3'],
+        agent4: ['state1', 'state2'],
+        agent5: ['state1'],
+      });
+    });
+    it('if display state is selected among other display states, it should be removed from selection array', () => {
+      const payload = getNewMapAfterDisplayStateClick(
+        'agent4',
+        'state1',
+        ['state1', 'state2', 'state3'],
+        mockVisibilitySelectionMap
+      );
+      expect(payload).toEqual({
+        agent1: ['agent1'],
+        agent2: ['agent2'],
+        agent3: [],
+        agent4: ['state2'],
+        agent5: ['state1'],
+      });
+    });
+    it('if clicked display state is the only current selection, it should return an array with the agent name', () => {
+      const payload = getNewMapAfterDisplayStateClick(
+        'agent5',
+        'state1',
+        ['state1', 'state2', 'state3'],
+        mockVisibilitySelectionMap
+      );
+      expect(payload).toEqual({
+        agent1: ['agent1'],
+        agent2: ['agent2'],
+        agent3: [],
+        agent4: ['state1', 'state2'],
+        agent5: ['agent5'],
+      });
+    });
+    it('if display state is clicked and selection array currently has agent name, replace it with display state name', () => {
+      const payload = getNewMapAfterDisplayStateClick(
+        'agent1',
+        'state1',
+        ['state1', 'state2', 'state3'],
+        mockVisibilitySelectionMap
+      );
+      expect(payload).toEqual({
+        agent1: ['state1'],
+        agent2: ['agent2'],
+        agent3: [],
+        agent4: ['state1', 'state2'],
+        agent5: ['state1'],
+      });
+    });
+    it('if adding clicked display state means all display states are selected, make selection array empty', () => {
+      const payload = getNewMapAfterDisplayStateClick(
+        'agent4',
+        'state3',
+        ['state1', 'state2', 'state3'],
+        mockVisibilitySelectionMap
+      );
+      expect(payload).toEqual({
+        agent1: ['agent1'],
+        agent2: ['agent2'],
+        agent3: [],
+        agent4: [],
+        agent5: ['state1'],
+      });
+    });
+    it('if adding clicked display state is leaves at least one display state unselected, add clicked state to array', () => {
+      const payload = getNewMapAfterDisplayStateClick(
+        'agent5',
+        'state2',
+        ['state1', 'state2', 'state3'],
+        mockVisibilitySelectionMap
+      );
+      expect(payload).toEqual({
+        agent1: ['agent1'],
+        agent2: ['agent2'],
+        agent3: [],
+        agent4: ['state1', 'state2'],
+        agent5: ['state1', 'state2'],
       });
     });
   });
 
+
   describe('convertMapToSelectionStateInfo', () => {
     it('returns an array of SelectionEntry objects', () => {
-      const payload = convertMapToSelectionStateInfo(mockVisibilitySelectionMap);
+      const payload = convertMapToSelectionStateInfo(
+        mockVisibilitySelectionMap
+      );
       expect(Array.isArray(payload)).toBe(true);
       expect(
         payload.every(
@@ -85,9 +239,10 @@ describe('utils for converting selection data types and handling selection actio
         },
       ]);
     });
-
     it('returns tags arrays with values when visibility selections have non-empty array values', () => {
-      const payload = convertMapToSelectionStateInfo(mockVisibilitySelectionMap);
+      const payload = convertMapToSelectionStateInfo(
+        mockVisibilitySelectionMap
+      );
       expect(payload).toEqual([
         {
           name: 'agent1',
@@ -101,7 +256,15 @@ describe('utils for converting selection data types and handling selection actio
           name: 'agent3',
           tags: [],
         },
+        {
+          name: 'agent4',
+          tags: ['state1', 'state2'],
+        },
+        {
+          name: 'agent5',
+          tags: ['state1'],
+        },
       ]);
     });
-  });
+});
 });

--- a/src/components/AgentRow.tsx
+++ b/src/components/AgentRow.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { UIDisplayEntry } from '@aics/simularium-viewer/type-declarations/simularium/SelectionInterface';
 
 import HideCheckbox from './HideCheckbox';
 import HighlightCheckbox from './HighlightCheckbox';
-import { ChildCheckboxProps } from '../types';
 import { Button } from 'antd';
 import ChildHideCheckbox from './ChildHideCheckbox';
 import ChildHighlightCheckbox from './ChildHighlightCheckbox';
+import { VisibilityContext } from '../AgentVisibilityContext';
+import { getChildren } from '../utils';
 
 interface AgentRowProps {
   agent: UIDisplayEntry;
@@ -17,18 +18,31 @@ const AgentRow: React.FC<AgentRowProps> = (
 ): JSX.Element => {
   const { agent } = props;
 
+  const {
+    handleHideCheckboxChange,
+    handleHideChildCheckboxChange,
+    handleHighlightChange,
+    handleChildHighlightChange,
+    highlightedAgents,
+    hiddenAgents,
+  } = useContext(VisibilityContext);
+  const highlightSelections = highlightedAgents[agent.name];
+  const hiddenSelections = hiddenAgents[agent.name];
+
   const [showChildren, setShowChildren] = React.useState(false);
   const hasChildren = agent.displayStates.length > 0;
 
   const getChildRows = (agent: UIDisplayEntry) => {
     return agent.displayStates.map((displayState) => {
-      const checkboxProps: ChildCheckboxProps = {
-        name: displayState.name,
-        parentName: agent.name,
-      };
       return (
         <div className="item-row" style={{ display: 'flex' }}>
-          <ChildHighlightCheckbox {...checkboxProps} />
+          <ChildHighlightCheckbox
+            name={displayState.name}
+            selections={highlightSelections}
+            clickHandler={() => {
+              handleChildHighlightChange(displayState.name, agent.name);
+            }}
+          />
           <div
             className="color-swatch"
             style={{
@@ -37,7 +51,13 @@ const AgentRow: React.FC<AgentRowProps> = (
               height: '12px',
             }}
           ></div>
-          <ChildHideCheckbox {...checkboxProps} />
+          <ChildHideCheckbox
+            name={displayState.name}
+            selections={hiddenSelections}
+            clickHandler={() =>
+              handleHideChildCheckboxChange(displayState.name, agent.name)
+            }
+          />
           <span>{displayState.name}</span>
         </div>
       );
@@ -45,11 +65,16 @@ const AgentRow: React.FC<AgentRowProps> = (
   };
 
   const childRows = hasChildren && getChildRows(agent);
+  const children = getChildren(agent);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
       <div className="item-row" style={{ display: 'flex' }}>
-        <HighlightCheckbox agent={agent} />
+        <HighlightCheckbox
+          agent={agent}
+          selections={highlightSelections}
+          clickHandler={() => handleHighlightChange(agent.name, children)}
+        />
         <div
           className="color-swatch"
           style={{
@@ -58,7 +83,11 @@ const AgentRow: React.FC<AgentRowProps> = (
             height: '12px',
           }}
         ></div>
-        <HideCheckbox agent={agent} />
+        <HideCheckbox
+          agent={agent}
+          selections={hiddenSelections}
+          clickHandler={() => handleHideCheckboxChange(agent.name, children)}
+        />
         <span>{agent.name}</span>
         {hasChildren && (
           <Button

--- a/src/components/AgentRow.tsx
+++ b/src/components/AgentRow.tsx
@@ -26,8 +26,8 @@ const AgentRow: React.FC<AgentRowProps> = (
     highlightedAgents,
     hiddenAgents,
   } = useContext(VisibilityContext);
-  const highlightSelections = highlightedAgents[agent.name];
-  const hiddenSelections = hiddenAgents[agent.name];
+  const highlightSelections = highlightedAgents[agent.name] || [];
+  const hiddenSelections = hiddenAgents[agent.name] || [];
 
   const [showChildren, setShowChildren] = React.useState(false);
   const hasChildren = agent.displayStates.length > 0;

--- a/src/components/AgentRow.tsx
+++ b/src/components/AgentRow.tsx
@@ -3,6 +3,8 @@ import { UIDisplayEntry } from '@aics/simularium-viewer/type-declarations/simula
 
 import HideCheckbox from './HideCheckbox';
 import HighlightCheckbox from './HighlightCheckbox';
+import { AgentProps, AgentType, DisplayStateProps } from '../types';
+import { Button } from 'antd';
 
 interface AgentRowProps {
   agent: UIDisplayEntry;
@@ -13,19 +15,67 @@ const AgentRow: React.FC<AgentRowProps> = (
 ): JSX.Element => {
   const { agent } = props;
 
+  const [showDisplayStates, setShowDisplayStates] = React.useState(false);
+  const hasDisplayStates = agent.displayStates.length > 0;
+
+  const getDisplayStateRows = (agent: UIDisplayEntry) => {
+    return agent.displayStates.map((displayState) => {
+      const checkboxProps: DisplayStateProps = {
+        agentType: AgentType.DisplayState,
+        agentName: agent.name,
+        displayStateName: displayState.name,
+      };
+      return (
+        <div className="item-row" style={{ display: 'flex' }}>
+          <HighlightCheckbox {...checkboxProps} />
+          <div
+            className="color-swatch"
+            style={{
+              backgroundColor: displayState.color,
+              width: '12px',
+              height: '12px',
+            }}
+          ></div>
+          <HideCheckbox {...checkboxProps} />
+          <span>{displayState.name}</span>
+        </div>
+      );
+    });
+  };
+
+  const displayStateRows = hasDisplayStates && getDisplayStateRows(agent);
+
+  const checkboxProps: AgentProps = {
+    agentType: AgentType.Agent,
+    agentName: agent.name,
+  };
+
   return (
-    <div className="item-row" style={{ display: 'flex' }}>
-      <HighlightCheckbox agent={agent} />
-      <div
-        className="color-swatch"
-        style={{
-          backgroundColor: agent.color,
-          width: '12px',
-          height: '12px',
-        }}
-      ></div>
-      <HideCheckbox agent={agent} />
-      <span>{agent.name}</span>
+    <div style={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
+      <div className="item-row" style={{ display: 'flex' }}>
+        <HighlightCheckbox {...checkboxProps} />
+        <div
+          className="color-swatch"
+          style={{
+            backgroundColor: agent.color,
+            width: '12px',
+            height: '12px',
+          }}
+        ></div>
+        <HideCheckbox {...checkboxProps} />
+        <span>{agent.name}</span>
+        {hasDisplayStates && (
+          <Button
+            style={{ paddingLeft: '30px' }}
+            onClick={() => setShowDisplayStates(!showDisplayStates)}
+          >
+            show display states
+          </Button>
+        )}
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
+        {showDisplayStates && displayStateRows}
+      </div>
     </div>
   );
 };

--- a/src/components/AgentRow.tsx
+++ b/src/components/AgentRow.tsx
@@ -3,8 +3,10 @@ import { UIDisplayEntry } from '@aics/simularium-viewer/type-declarations/simula
 
 import HideCheckbox from './HideCheckbox';
 import HighlightCheckbox from './HighlightCheckbox';
-import { ParentAgentProps, AgentLevel, ChildAgentProps } from '../types';
+import { ChildCheckboxProps } from '../types';
 import { Button } from 'antd';
+import ChildHideCheckbox from './ChildHideCheckbox';
+import ChildHighlightCheckbox from './ChildHighlightCheckbox';
 
 interface AgentRowProps {
   agent: UIDisplayEntry;
@@ -20,14 +22,13 @@ const AgentRow: React.FC<AgentRowProps> = (
 
   const getChildRows = (agent: UIDisplayEntry) => {
     return agent.displayStates.map((displayState) => {
-      const checkboxProps: ChildAgentProps = {
-        agentLevel: AgentLevel.ChildAgent,
-        agentName: agent.name,
-        childName: displayState.name,
+      const checkboxProps: ChildCheckboxProps = {
+        name: displayState.name,
+        parentName: agent.name,
       };
       return (
         <div className="item-row" style={{ display: 'flex' }}>
-          <HighlightCheckbox {...checkboxProps} />
+          <ChildHighlightCheckbox {...checkboxProps} />
           <div
             className="color-swatch"
             style={{
@@ -36,7 +37,7 @@ const AgentRow: React.FC<AgentRowProps> = (
               height: '12px',
             }}
           ></div>
-          <HideCheckbox {...checkboxProps} />
+          <ChildHideCheckbox {...checkboxProps} />
           <span>{displayState.name}</span>
         </div>
       );
@@ -45,15 +46,10 @@ const AgentRow: React.FC<AgentRowProps> = (
 
   const childRows = hasChildren && getChildRows(agent);
 
-  const checkboxProps: ParentAgentProps = {
-    agentLevel: AgentLevel.Agent,
-    agentName: agent.name,
-  };
-
   return (
     <div style={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
       <div className="item-row" style={{ display: 'flex' }}>
-        <HighlightCheckbox {...checkboxProps} />
+        <HighlightCheckbox agent={agent} />
         <div
           className="color-swatch"
           style={{
@@ -62,7 +58,7 @@ const AgentRow: React.FC<AgentRowProps> = (
             height: '12px',
           }}
         ></div>
-        <HideCheckbox {...checkboxProps} />
+        <HideCheckbox agent={agent} />
         <span>{agent.name}</span>
         {hasChildren && (
           <Button

--- a/src/components/AgentRow.tsx
+++ b/src/components/AgentRow.tsx
@@ -3,7 +3,7 @@ import { UIDisplayEntry } from '@aics/simularium-viewer/type-declarations/simula
 
 import HideCheckbox from './HideCheckbox';
 import HighlightCheckbox from './HighlightCheckbox';
-import { AgentProps, AgentType, DisplayStateProps } from '../types';
+import { ParentAgentProps, AgentLevel, ChildAgentProps } from '../types';
 import { Button } from 'antd';
 
 interface AgentRowProps {
@@ -15,15 +15,15 @@ const AgentRow: React.FC<AgentRowProps> = (
 ): JSX.Element => {
   const { agent } = props;
 
-  const [showDisplayStates, setShowDisplayStates] = React.useState(false);
-  const hasDisplayStates = agent.displayStates.length > 0;
+  const [showChildren, setShowChildren] = React.useState(false);
+  const hasChildren = agent.displayStates.length > 0;
 
-  const getDisplayStateRows = (agent: UIDisplayEntry) => {
+  const getChildRows = (agent: UIDisplayEntry) => {
     return agent.displayStates.map((displayState) => {
-      const checkboxProps: DisplayStateProps = {
-        agentType: AgentType.DisplayState,
+      const checkboxProps: ChildAgentProps = {
+        agentLevel: AgentLevel.ChildAgent,
         agentName: agent.name,
-        displayStateName: displayState.name,
+        childName: displayState.name,
       };
       return (
         <div className="item-row" style={{ display: 'flex' }}>
@@ -43,10 +43,10 @@ const AgentRow: React.FC<AgentRowProps> = (
     });
   };
 
-  const displayStateRows = hasDisplayStates && getDisplayStateRows(agent);
+  const childRows = hasChildren && getChildRows(agent);
 
-  const checkboxProps: AgentProps = {
-    agentType: AgentType.Agent,
+  const checkboxProps: ParentAgentProps = {
+    agentLevel: AgentLevel.Agent,
     agentName: agent.name,
   };
 
@@ -64,17 +64,17 @@ const AgentRow: React.FC<AgentRowProps> = (
         ></div>
         <HideCheckbox {...checkboxProps} />
         <span>{agent.name}</span>
-        {hasDisplayStates && (
+        {hasChildren && (
           <Button
             style={{ paddingLeft: '30px' }}
-            onClick={() => setShowDisplayStates(!showDisplayStates)}
+            onClick={() => setShowChildren(!showChildren)}
           >
-            show display states
+            show child rows
           </Button>
         )}
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
-        {showDisplayStates && displayStateRows}
+        {showChildren && childRows}
       </div>
     </div>
   );

--- a/src/components/ChildHideCheckbox.tsx
+++ b/src/components/ChildHideCheckbox.tsx
@@ -25,7 +25,7 @@ const ChildHideCheckbox: React.FunctionComponent<ChildCheckboxProps> = (
   const tooltipText = tooltipMap[checkboxStatus];
 
   return (
-    <Tooltip placement="right" title={tooltipText} trigger=["focus", "hover"]>
+    <Tooltip placement="right" title={tooltipText} trigger={['focus', 'hover']}>
       <Checkbox
         checked={checkboxStatus === 'Checked'}
         onClick={() => handleHideChildCheckboxChange(name, parentName)}

--- a/src/components/ChildHideCheckbox.tsx
+++ b/src/components/ChildHideCheckbox.tsx
@@ -12,7 +12,9 @@ const ChildHideCheckbox: React.FunctionComponent<ChildCheckboxProps> = (
   const { handleHideChildCheckboxChange, hiddenAgents } =
     useContext(VisibilityContext);
 
-  const selections = hiddenAgents[parentName];
+  // the selections are initialized with the parents names as keys,
+  // so this will always exist, but typeScript doesn't know that.
+  const selections = hiddenAgents[parentName] || [];
 
   const getCheckboxStatus = () => {
     if (selections?.includes(name)) {

--- a/src/components/ChildHideCheckbox.tsx
+++ b/src/components/ChildHideCheckbox.tsx
@@ -25,7 +25,7 @@ const ChildHideCheckbox: React.FunctionComponent<ChildCheckboxProps> = (
   const tooltipText = tooltipMap[checkboxStatus];
 
   return (
-    <Tooltip placement="right" title={tooltipText}>
+    <Tooltip placement="right" title={tooltipText} trigger=["focus", "hover"]>
       <Checkbox
         checked={checkboxStatus === 'Checked'}
         onClick={() => handleHideChildCheckboxChange(name, parentName)}

--- a/src/components/ChildHideCheckbox.tsx
+++ b/src/components/ChildHideCheckbox.tsx
@@ -1,0 +1,37 @@
+import React, { useContext } from 'react';
+import { Checkbox, Tooltip } from 'antd';
+
+import { ChildCheckboxProps } from '../types';
+import { VisibilityContext } from '../AgentVisibilityContext';
+import { CheckboxState, tooltipMap } from '../constants';
+
+const ChildHideCheckbox: React.FunctionComponent<ChildCheckboxProps> = (
+  props: ChildCheckboxProps
+): JSX.Element => {
+  const { name, parentName } = props;
+  const { handleHideChildCheckboxChange, hiddenAgents } =
+    useContext(VisibilityContext);
+
+  const selections = hiddenAgents[parentName];
+
+  const getCheckboxStatus = () => {
+    if (selections?.includes(name)) {
+      return CheckboxState.Checked;
+    }
+    return CheckboxState.Unchecked;
+  };
+
+  const checkboxStatus = getCheckboxStatus();
+  const tooltipText = tooltipMap[checkboxStatus];
+
+  return (
+    <Tooltip placement="right" title={tooltipText}>
+      <Checkbox
+        checked={checkboxStatus === 'Checked'}
+        onClick={() => handleHideChildCheckboxChange(name, parentName)}
+      />
+    </Tooltip>
+  );
+};
+
+export default ChildHideCheckbox;

--- a/src/components/ChildHideCheckbox.tsx
+++ b/src/components/ChildHideCheckbox.tsx
@@ -16,9 +16,9 @@ const ChildHideCheckbox: React.FunctionComponent<ChildCheckboxProps> = (
 
   const getCheckboxStatus = () => {
     if (selections?.includes(name)) {
-      return CheckboxState.Checked;
+      return CheckboxState.Unchecked;
     }
-    return CheckboxState.Unchecked;
+    return CheckboxState.Checked;
   };
 
   const checkboxStatus = getCheckboxStatus();

--- a/src/components/ChildHideCheckbox.tsx
+++ b/src/components/ChildHideCheckbox.tsx
@@ -1,23 +1,16 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { Checkbox, Tooltip } from 'antd';
 
 import { ChildCheckboxProps } from '../types';
-import { VisibilityContext } from '../AgentVisibilityContext';
 import { CheckboxState, tooltipMap } from '../constants';
 
 const ChildHideCheckbox: React.FunctionComponent<ChildCheckboxProps> = (
   props: ChildCheckboxProps
 ): JSX.Element => {
-  const { name, parentName } = props;
-  const { handleHideChildCheckboxChange, hiddenAgents } =
-    useContext(VisibilityContext);
-
-  // the selections are initialized with the parents names as keys,
-  // so this will always exist, but typeScript doesn't know that.
-  const selections = hiddenAgents[parentName] || [];
+  const { name, selections, clickHandler } = props;
 
   const getCheckboxStatus = () => {
-    if (selections?.includes(name)) {
+    if (selections.includes(name)) {
       return CheckboxState.Unchecked;
     }
     return CheckboxState.Checked;
@@ -28,10 +21,7 @@ const ChildHideCheckbox: React.FunctionComponent<ChildCheckboxProps> = (
 
   return (
     <Tooltip placement="right" title={tooltipText} trigger={['focus', 'hover']}>
-      <Checkbox
-        checked={checkboxStatus === 'Checked'}
-        onClick={() => handleHideChildCheckboxChange(name, parentName)}
-      />
+      <Checkbox checked={checkboxStatus === 'Checked'} onClick={clickHandler} />
     </Tooltip>
   );
 };

--- a/src/components/ChildHighlightCheckbox.tsx
+++ b/src/components/ChildHighlightCheckbox.tsx
@@ -22,9 +22,9 @@ const ChildHighlightCheckbox: React.FunctionComponent<ChildCheckboxProps> = (
 
   const getCheckboxStatus = () => {
     if (selections?.includes(name)) {
-      return CheckboxState.Unchecked;
+      return CheckboxState.Checked;
     }
-    return CheckboxState.Checked;
+    return CheckboxState.Unchecked;
   };
 
   const getHighlightDisplayOptions = (

--- a/src/components/ChildHighlightCheckbox.tsx
+++ b/src/components/ChildHighlightCheckbox.tsx
@@ -2,35 +2,29 @@ import React, { useContext } from 'react';
 import { Tooltip } from 'antd';
 
 import { CheckboxState } from '../constants';
-import { CheckboxProps, HighlightDisplayOption } from '../types';
+import { ChildCheckboxProps, HighlightDisplayOption } from '../types';
 import { VisibilityContext } from '../AgentVisibilityContext';
 import {
   HighlightStar,
   IndeterminateHighlightStar,
   NoHighlightStar,
 } from './Icons';
-import { getChildren } from '../utils';
 
-const HighlightCheckbox: React.FunctionComponent<CheckboxProps> = (
-  props: CheckboxProps
+const ChildHighlightCheckbox: React.FunctionComponent<ChildCheckboxProps> = (
+  props: ChildCheckboxProps
 ): JSX.Element => {
-  const { agent } = props;
+  const { name, parentName } = props;
 
-  const { handleHighlightChange, highlightedAgents } =
+  const { handleChildHighlightChange, highlightedAgents } =
     useContext(VisibilityContext);
 
-  const selections = highlightedAgents[agent.name];
-  const maxSelections =
-    agent.displayStates.length > 0 ? agent.displayStates.length : 1;
+  const selections = highlightedAgents[parentName];
 
   const getCheckboxStatus = () => {
-    if (selections?.length === 0) {
-      return CheckboxState.Checked;
-    }
-    if (selections?.length === maxSelections) {
+    if (selections?.includes(name)) {
       return CheckboxState.Unchecked;
     }
-    return CheckboxState.Indeterminate;
+    return CheckboxState.Checked;
   };
 
   const getHighlightDisplayOptions = (
@@ -61,7 +55,6 @@ const HighlightCheckbox: React.FunctionComponent<CheckboxProps> = (
   const checkboxStatus = getCheckboxStatus();
   const { tooltipText, ariaLabel, icon } =
     getHighlightDisplayOptions(checkboxStatus);
-  const children = getChildren(agent);
 
   return (
     <Tooltip placement="top" title={tooltipText}>
@@ -74,11 +67,11 @@ const HighlightCheckbox: React.FunctionComponent<CheckboxProps> = (
           opacity: 0,
           cursor: 'pointer',
         }}
-        onClick={() => handleHighlightChange(agent.name, children)}
+        onClick={() => handleChildHighlightChange(name, parentName)}
       />
       <label style={{ fill: '#d3d3d3' }}>{icon}</label>
     </Tooltip>
   );
 };
 
-export default HighlightCheckbox;
+export default ChildHighlightCheckbox;

--- a/src/components/ChildHighlightCheckbox.tsx
+++ b/src/components/ChildHighlightCheckbox.tsx
@@ -57,7 +57,7 @@ const ChildHighlightCheckbox: React.FunctionComponent<ChildCheckboxProps> = (
     getHighlightDisplayOptions(checkboxStatus);
 
   return (
-    <Tooltip placement="top" title={tooltipText}>
+    <Tooltip placement="top" title={tooltipText} trigger={['focus', 'hover']}>
       <input
         type="checkbox"
         aria-label={ariaLabel}

--- a/src/components/ChildHighlightCheckbox.tsx
+++ b/src/components/ChildHighlightCheckbox.tsx
@@ -18,7 +18,9 @@ const ChildHighlightCheckbox: React.FunctionComponent<ChildCheckboxProps> = (
   const { handleChildHighlightChange, highlightedAgents } =
     useContext(VisibilityContext);
 
-  const selections = highlightedAgents[parentName];
+  // the selections are initialized with the parents names as keys,
+  // so this will always exist, but typeScript doesn't know that.
+  const selections = highlightedAgents[parentName] || [];
 
   const getCheckboxStatus = () => {
     if (selections?.includes(name)) {

--- a/src/components/ChildHighlightCheckbox.tsx
+++ b/src/components/ChildHighlightCheckbox.tsx
@@ -1,9 +1,8 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { Tooltip } from 'antd';
 
 import { CheckboxState } from '../constants';
 import { ChildCheckboxProps, HighlightDisplayOption } from '../types';
-import { VisibilityContext } from '../AgentVisibilityContext';
 import {
   HighlightStar,
   IndeterminateHighlightStar,
@@ -13,17 +12,10 @@ import {
 const ChildHighlightCheckbox: React.FunctionComponent<ChildCheckboxProps> = (
   props: ChildCheckboxProps
 ): JSX.Element => {
-  const { name, parentName } = props;
-
-  const { handleChildHighlightChange, highlightedAgents } =
-    useContext(VisibilityContext);
-
-  // the selections are initialized with the parents names as keys,
-  // so this will always exist, but typeScript doesn't know that.
-  const selections = highlightedAgents[parentName] || [];
+  const { name, selections, clickHandler } = props;
 
   const getCheckboxStatus = () => {
-    if (selections?.includes(name)) {
+    if (selections.includes(name)) {
       return CheckboxState.Checked;
     }
     return CheckboxState.Unchecked;
@@ -69,7 +61,7 @@ const ChildHighlightCheckbox: React.FunctionComponent<ChildCheckboxProps> = (
           opacity: 0,
           cursor: 'pointer',
         }}
-        onClick={() => handleChildHighlightChange(name, parentName)}
+        onClick={clickHandler}
       />
       <label style={{ fill: '#d3d3d3' }}>{icon}</label>
     </Tooltip>

--- a/src/components/HideAllAgentsCheckbox.tsx
+++ b/src/components/HideAllAgentsCheckbox.tsx
@@ -4,7 +4,7 @@ import { isEqual } from '@jupyter-widgets/base';
 
 import { CheckboxState, UserChangesMap } from '../constants';
 import { VisibilityContext } from '../AgentVisibilityContext';
-import { mapUIDisplayDataToSelectionMap } from '../utils';
+import { getInitialUserSelections } from '../utils';
 
 const HideAllAgentsCheckbox: React.FunctionComponent = (): JSX.Element => {
   const { setHiddenAgents, hiddenAgents, uiDisplayData } =
@@ -14,8 +14,8 @@ const HideAllAgentsCheckbox: React.FunctionComponent = (): JSX.Element => {
    * The maps below are values to use when clicking the checkbox, they are
    * essentially constant and only need to be computed when the uiDisplayData changes.
    */
-  const noAgentsSelectedMap = useMemo(() => {
-    return mapUIDisplayDataToSelectionMap(uiDisplayData);
+  const initialUserSelections = useMemo(() => {
+    return getInitialUserSelections(uiDisplayData);
   }, [uiDisplayData]);
 
   const allAgentsSelectedMap = useMemo(() => {
@@ -33,7 +33,7 @@ const HideAllAgentsCheckbox: React.FunctionComponent = (): JSX.Element => {
     const newValue =
       checkboxStatus === CheckboxState.Checked
         ? allAgentsSelectedMap
-        : noAgentsSelectedMap;
+        : initialUserSelections;
     setHiddenAgents(newValue);
   };
 
@@ -44,7 +44,7 @@ const HideAllAgentsCheckbox: React.FunctionComponent = (): JSX.Element => {
   };
 
   const getCheckboxStatus = () => {
-    if (isEqual(hiddenAgents, noAgentsSelectedMap)) {
+    if (isEqual(hiddenAgents, initialUserSelections)) {
       return CheckboxState.Checked;
     }
     if (isEqual(hiddenAgents, allAgentsSelectedMap)) {

--- a/src/components/HideAllAgentsCheckbox.tsx
+++ b/src/components/HideAllAgentsCheckbox.tsx
@@ -27,8 +27,8 @@ const HideAllAgentsCheckbox: React.FunctionComponent = (): JSX.Element => {
   const clickHandler = () => {
     const newValue =
       checkboxStatus === CheckboxState.Checked
-        ? noAgentsSelectedMap
-        : allAgentsSelectedMap;
+        ? allAgentsSelectedMap
+        : noAgentsSelectedMap;
     setHiddenAgents(newValue);
   };
 

--- a/src/components/HideAllAgentsCheckbox.tsx
+++ b/src/components/HideAllAgentsCheckbox.tsx
@@ -4,7 +4,7 @@ import { isEqual } from '@jupyter-widgets/base';
 
 import { CheckboxState, UserChangesMap } from '../constants';
 import { VisibilityContext } from '../AgentVisibilityContext';
-import { getInitialUserSelections } from '../utils';
+import { makeEmptyUserSelections } from '../utils';
 
 const HideAllAgentsCheckbox: React.FunctionComponent = (): JSX.Element => {
   const { setHiddenAgents, hiddenAgents, uiDisplayData } =
@@ -15,7 +15,7 @@ const HideAllAgentsCheckbox: React.FunctionComponent = (): JSX.Element => {
    * essentially constant and only need to be computed when the uiDisplayData changes.
    */
   const initialUserSelections = useMemo(() => {
-    return getInitialUserSelections(uiDisplayData);
+    return makeEmptyUserSelections(uiDisplayData);
   }, [uiDisplayData]);
 
   const allAgentsSelectedMap = useMemo(() => {

--- a/src/components/HideAllAgentsCheckbox.tsx
+++ b/src/components/HideAllAgentsCheckbox.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useMemo } from 'react';
 import { Checkbox, Tooltip } from 'antd';
 import { isEqual } from '@jupyter-widgets/base';
 
-import { CheckboxState } from '../constants';
+import { CheckboxState, UserChangesMap } from '../constants';
 import { VisibilityContext } from '../AgentVisibilityContext';
 import { mapUIDisplayDataToSelectionMap } from '../utils';
 
@@ -19,9 +19,10 @@ const HideAllAgentsCheckbox: React.FunctionComponent = (): JSX.Element => {
   }, [uiDisplayData]);
 
   const allAgentsSelectedMap = useMemo(() => {
-    // the boolean tells the util to select all agents, it defaults to false
-    const selectAllAgents = true;
-    return mapUIDisplayDataToSelectionMap(uiDisplayData, selectAllAgents);
+    return uiDisplayData.reduce<UserChangesMap>((acc, agent) => {
+      acc[agent.name] = [];
+      return acc;
+    }, {});
   }, [uiDisplayData]);
 
   const clickHandler = () => {

--- a/src/components/HideAllAgentsCheckbox.tsx
+++ b/src/components/HideAllAgentsCheckbox.tsx
@@ -20,7 +20,11 @@ const HideAllAgentsCheckbox: React.FunctionComponent = (): JSX.Element => {
 
   const allAgentsSelectedMap = useMemo(() => {
     return uiDisplayData.reduce<UserChangesMap>((acc, agent) => {
-      acc[agent.name] = [];
+      if (agent.displayStates && agent.displayStates.length > 0) {
+        acc[agent.name] = [...agent.displayStates.map((state) => state.id)];
+      } else {
+        acc[agent.name] = [agent.name];
+      }
       return acc;
     }, {});
   }, [uiDisplayData]);

--- a/src/components/HideAllAgentsCheckbox.tsx
+++ b/src/components/HideAllAgentsCheckbox.tsx
@@ -57,7 +57,7 @@ const HideAllAgentsCheckbox: React.FunctionComponent = (): JSX.Element => {
   const tooltipText = tooltipMap[checkboxStatus];
 
   return (
-    <Tooltip placement="right" title={tooltipText}>
+    <Tooltip placement="right" title={tooltipText} trigger={['focus', 'hover']}>
       <Checkbox
         indeterminate={checkboxStatus === 'Indeterminate'}
         checked={checkboxStatus === 'Checked'}

--- a/src/components/HideCheckbox.tsx
+++ b/src/components/HideCheckbox.tsx
@@ -19,10 +19,10 @@ const HideCheckbox: React.FunctionComponent<CheckboxProps> = (
 
   const getCheckboxStatus = () => {
     if (selections?.length === 0) {
-      return CheckboxState.Unchecked;
+      return CheckboxState.Checked;
     }
     if (selections?.length === maxSelections) {
-      return CheckboxState.Checked;
+      return CheckboxState.Unchecked;
     }
     return CheckboxState.Indeterminate;
   };

--- a/src/components/HideCheckbox.tsx
+++ b/src/components/HideCheckbox.tsx
@@ -32,7 +32,7 @@ const HideCheckbox: React.FunctionComponent<CheckboxProps> = (
   const children = getChildren(agent);
 
   return (
-    <Tooltip placement="right" title={tooltipText}>
+    <Tooltip placement="right" title={tooltipText} trigger={['focus', 'hover']}>
       <Checkbox
         indeterminate={checkboxStatus === 'Indeterminate'}
         checked={checkboxStatus === 'Checked'}

--- a/src/components/HideCheckbox.tsx
+++ b/src/components/HideCheckbox.tsx
@@ -1,27 +1,22 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { Checkbox, Tooltip } from 'antd';
 
 import { CheckboxProps } from '../types';
-import { VisibilityContext } from '../AgentVisibilityContext';
 import { CheckboxState, tooltipMap } from '../constants';
-import { getChildren } from '../utils';
 
 const HideCheckbox: React.FunctionComponent<CheckboxProps> = (
   props: CheckboxProps
 ): JSX.Element => {
-  const { agent } = props;
-  const { handleHideCheckboxChange, hiddenAgents } =
-    useContext(VisibilityContext);
+  const { agent, selections, clickHandler } = props;
 
-  const selections = hiddenAgents[agent.name];
   const maxSelections =
     agent.displayStates.length > 0 ? agent.displayStates.length : 1;
 
   const getCheckboxStatus = () => {
-    if (selections?.length === 0) {
+    if (selections.length === 0) {
       return CheckboxState.Checked;
     }
-    if (selections?.length === maxSelections) {
+    if (selections.length === maxSelections) {
       return CheckboxState.Unchecked;
     }
     return CheckboxState.Indeterminate;
@@ -29,14 +24,13 @@ const HideCheckbox: React.FunctionComponent<CheckboxProps> = (
 
   const checkboxStatus = getCheckboxStatus();
   const tooltipText = tooltipMap[checkboxStatus];
-  const children = getChildren(agent);
 
   return (
     <Tooltip placement="right" title={tooltipText} trigger={['focus', 'hover']}>
       <Checkbox
         indeterminate={checkboxStatus === 'Indeterminate'}
         checked={checkboxStatus === 'Checked'}
-        onClick={() => handleHideCheckboxChange(agent.name, children)}
+        onClick={clickHandler}
       />
     </Tooltip>
   );

--- a/src/components/HideCheckbox.tsx
+++ b/src/components/HideCheckbox.tsx
@@ -1,48 +1,42 @@
 import React, { useContext } from 'react';
 import { Checkbox, Tooltip } from 'antd';
 
-import { CustomCheckboxProps } from '../types';
+import { CheckboxProps } from '../types';
 import { VisibilityContext } from '../AgentVisibilityContext';
 import { CheckboxState, tooltipMap } from '../constants';
+import { getChildren } from '../utils';
 
-const HideCheckbox: React.FunctionComponent<CustomCheckboxProps> = (
-  props: CustomCheckboxProps
+const HideCheckbox: React.FunctionComponent<CheckboxProps> = (
+  props: CheckboxProps
 ): JSX.Element => {
-  const { agentName, childName } = props;
-  const { handleVisibilityCheckboxChange, hiddenAgents } =
+  const { agent } = props;
+  const { handleHideCheckboxChange, hiddenAgents } =
     useContext(VisibilityContext);
 
-  const selections = hiddenAgents[agentName];
-  const isTopLevel = childName === undefined;
+  const selections = hiddenAgents[agent.name];
+  const maxSelections =
+    agent.displayStates.length > 0 ? agent.displayStates.length : 1;
 
-  const determineTopLevelCheckboxStatus = () => {
+  const getCheckboxStatus = () => {
     if (selections?.length === 0) {
       return CheckboxState.Unchecked;
     }
-    if (selections?.includes(agentName)) {
+    if (selections?.length === maxSelections) {
       return CheckboxState.Checked;
     }
     return CheckboxState.Indeterminate;
   };
 
-  const determineChildAgentCheckboxStatus = (childName: string) => {
-    if (selections?.includes(childName) || selections?.length === 0) {
-      return CheckboxState.Unchecked;
-    }
-    return CheckboxState.Checked;
-  };
-
-  const checkboxStatus = isTopLevel
-    ? determineTopLevelCheckboxStatus()
-    : determineChildAgentCheckboxStatus(childName);
+  const checkboxStatus = getCheckboxStatus();
   const tooltipText = tooltipMap[checkboxStatus];
+  const children = getChildren(agent);
 
   return (
     <Tooltip placement="right" title={tooltipText}>
       <Checkbox
         indeterminate={checkboxStatus === 'Indeterminate'}
         checked={checkboxStatus === 'Checked'}
-        onClick={() => handleVisibilityCheckboxChange(agentName, childName)}
+        onClick={() => handleHideCheckboxChange(agent.name, children)}
       />
     </Tooltip>
   );

--- a/src/components/HideCheckbox.tsx
+++ b/src/components/HideCheckbox.tsx
@@ -8,12 +8,12 @@ import { CheckboxState, tooltipMap } from '../constants';
 const HideCheckbox: React.FunctionComponent<CustomCheckboxProps> = (
   props: CustomCheckboxProps
 ): JSX.Element => {
-  const { agentName, displayStateName } = props;
+  const { agentName, childName } = props;
   const { handleVisibilityCheckboxChange, hiddenAgents } =
     useContext(VisibilityContext);
 
   const selections = hiddenAgents[agentName];
-  const isTopLevel = displayStateName === undefined;
+  const isTopLevel = childName === undefined;
 
   const determineTopLevelCheckboxStatus = () => {
     if (selections?.length === 0) {
@@ -25,8 +25,8 @@ const HideCheckbox: React.FunctionComponent<CustomCheckboxProps> = (
     return CheckboxState.Indeterminate;
   };
 
-  const determineDisplayStateCheckboxStatus = (displayStateName: string) => {
-    if (selections?.includes(displayStateName) || selections?.length === 0) {
+  const determineChildAgentCheckboxStatus = (childName: string) => {
+    if (selections?.includes(childName) || selections?.length === 0) {
       return CheckboxState.Unchecked;
     }
     return CheckboxState.Checked;
@@ -34,7 +34,7 @@ const HideCheckbox: React.FunctionComponent<CustomCheckboxProps> = (
 
   const checkboxStatus = isTopLevel
     ? determineTopLevelCheckboxStatus()
-    : determineDisplayStateCheckboxStatus(displayStateName);
+    : determineChildAgentCheckboxStatus(childName);
   const tooltipText = tooltipMap[checkboxStatus];
 
   return (
@@ -42,9 +42,7 @@ const HideCheckbox: React.FunctionComponent<CustomCheckboxProps> = (
       <Checkbox
         indeterminate={checkboxStatus === 'Indeterminate'}
         checked={checkboxStatus === 'Checked'}
-        onClick={() =>
-          handleVisibilityCheckboxChange(agentName, displayStateName)
-        }
+        onClick={() => handleVisibilityCheckboxChange(agentName, childName)}
       />
     </Tooltip>
   );

--- a/src/components/HighlightCheckbox.tsx
+++ b/src/components/HighlightCheckbox.tsx
@@ -25,10 +25,10 @@ const HighlightCheckbox: React.FunctionComponent<CheckboxProps> = (
 
   const getCheckboxStatus = () => {
     if (selections?.length === 0) {
-      return CheckboxState.Checked;
+      return CheckboxState.Unchecked;
     }
     if (selections?.length === maxSelections) {
-      return CheckboxState.Unchecked;
+      return CheckboxState.Checked;
     }
     return CheckboxState.Indeterminate;
   };

--- a/src/components/HighlightCheckbox.tsx
+++ b/src/components/HighlightCheckbox.tsx
@@ -64,7 +64,7 @@ const HighlightCheckbox: React.FunctionComponent<CheckboxProps> = (
   const children = getChildren(agent);
 
   return (
-    <Tooltip placement="top" title={tooltipText}>
+    <Tooltip placement="top" title={tooltipText} trigger={['focus', 'hover']}>
       <input
         type="checkbox"
         aria-label={ariaLabel}

--- a/src/components/HighlightCheckbox.tsx
+++ b/src/components/HighlightCheckbox.tsx
@@ -13,13 +13,13 @@ import {
 const HighlightCheckbox: React.FunctionComponent<CustomCheckboxProps> = (
   props: CustomCheckboxProps
 ): JSX.Element => {
-  const { agentName, displayStateName } = props;
+  const { agentName, childName } = props;
 
   const { handleHightlightCheckboxChange, highlightedAgents } =
     useContext(VisibilityContext);
 
   const selections = highlightedAgents[agentName];
-  const isTopLevel = displayStateName === undefined;
+  const isTopLevel = childName === undefined;
 
   const determineTopLevelCheckboxStatus = () => {
     if (selections?.length === 0) {
@@ -31,8 +31,8 @@ const HighlightCheckbox: React.FunctionComponent<CustomCheckboxProps> = (
     return CheckboxState.Indeterminate;
   };
 
-  const determineDisplayStateCheckboxStatus = (displayStateName: string) => {
-    if (selections?.includes(displayStateName) || selections?.length === 0) {
+  const determineChildAgentCheckboxStatus = (childName: string) => {
+    if (selections?.includes(childName) || selections?.length === 0) {
       return CheckboxState.Checked;
     }
     return CheckboxState.Unchecked;
@@ -64,7 +64,7 @@ const HighlightCheckbox: React.FunctionComponent<CustomCheckboxProps> = (
 
   const checkboxStatus = isTopLevel
     ? determineTopLevelCheckboxStatus()
-    : determineDisplayStateCheckboxStatus(displayStateName);
+    : determineChildAgentCheckboxStatus(childName);
   const { tooltipText, ariaLabel, icon } =
     getHighlightDisplayOptions(checkboxStatus);
 
@@ -79,9 +79,7 @@ const HighlightCheckbox: React.FunctionComponent<CustomCheckboxProps> = (
           opacity: 0,
           cursor: 'pointer',
         }}
-        onClick={() =>
-          handleHightlightCheckboxChange(agentName, displayStateName)
-        }
+        onClick={() => handleHightlightCheckboxChange(agentName, childName)}
       />
       <label style={{ fill: '#d3d3d3' }}>{icon}</label>
     </Tooltip>

--- a/src/components/HighlightCheckbox.tsx
+++ b/src/components/HighlightCheckbox.tsx
@@ -1,33 +1,27 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { Tooltip } from 'antd';
 
 import { CheckboxState } from '../constants';
 import { CheckboxProps, HighlightDisplayOption } from '../types';
-import { VisibilityContext } from '../AgentVisibilityContext';
 import {
   HighlightStar,
   IndeterminateHighlightStar,
   NoHighlightStar,
 } from './Icons';
-import { getChildren } from '../utils';
 
 const HighlightCheckbox: React.FunctionComponent<CheckboxProps> = (
   props: CheckboxProps
 ): JSX.Element => {
-  const { agent } = props;
+  const { agent, selections, clickHandler } = props;
 
-  const { handleHighlightChange, highlightedAgents } =
-    useContext(VisibilityContext);
-
-  const selections = highlightedAgents[agent.name];
   const maxSelections =
     agent.displayStates.length > 0 ? agent.displayStates.length : 1;
 
   const getCheckboxStatus = () => {
-    if (selections?.length === 0) {
+    if (selections.length === 0) {
       return CheckboxState.Unchecked;
     }
-    if (selections?.length === maxSelections) {
+    if (selections.length === maxSelections) {
       return CheckboxState.Checked;
     }
     return CheckboxState.Indeterminate;
@@ -61,7 +55,6 @@ const HighlightCheckbox: React.FunctionComponent<CheckboxProps> = (
   const checkboxStatus = getCheckboxStatus();
   const { tooltipText, ariaLabel, icon } =
     getHighlightDisplayOptions(checkboxStatus);
-  const children = getChildren(agent);
 
   return (
     <Tooltip placement="top" title={tooltipText} trigger={['focus', 'hover']}>
@@ -74,7 +67,7 @@ const HighlightCheckbox: React.FunctionComponent<CheckboxProps> = (
           opacity: 0,
           cursor: 'pointer',
         }}
-        onClick={() => handleHighlightChange(agent.name, children)}
+        onClick={clickHandler}
       />
       <label style={{ fill: '#d3d3d3' }}>{icon}</label>
     </Tooltip>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,7 +26,7 @@ export const VIEWER_INITIAL_WIDTH: number = 500;
 export const VIEWER_HEIGHT: number = 580;
 
 /**
- * The UserChangesMap stores user changes to highlighting and hiding (made by clicking checkboxes).
+ * A UserChangesMap stores user changes to highlighting and hiding (made by clicking checkboxes).
  * There should be a key in the map for each agent name,
  * and the value is an array to hold user changes to selection: hiding and highlighting.
  * The default state of the value array is to be empty.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,15 +26,15 @@ export const VIEWER_INITIAL_WIDTH: number = 500;
 export const VIEWER_HEIGHT: number = 580;
 
 /**
- * The UserChangesMap stores user changes to highlighting and hiding checkboxes.
- * If a user highlights an agent or display state, that "star" checkbox will be checked.
- * If a user hides an agent or display state, that checkbox will be checked.
- * The selection state info for the viewer is derived from these maps.
- * The default state is to include the agent name, or if an agent has multiple display states,
- * all of the display state names.
- * userChangesMap[agentName] = [] means nothing is selected
- * userChangesMap[agentName] = [agentName] means the agent is selected in a case with no display states
- * userChangesMap[agentName] = [displayState1, displayState2] means whatever display states are in the array are selected
+ * The UserChangesMap stores user changes to highlighting and hiding (made by clicking checkboxes).
+ * There should be a key in the map for each agent name,
+ * and the value is an array to hold user changes to selection: hiding and highlighting.
+ * The default state of the value array is to be empty.
+ * If an agent with no display states is hidden or highlighted, the array will contain the agent name.
+ * If an agent has display states, those states that are hidden/highlighted will be in the array.
+ * userChangesMap[agentName] = [] means nothing is hidden/highlighted
+ * userChangesMap[agentName] = [agentName] means the agent is hidden/highlighted in a case with no display states
+ * userChangesMap[agentName] = [displayState1, displayState2] means whatever display states are in the array are hidden/highlighted
  */
 export interface UserChangesMap {
   [key: string]: string[];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,3 +33,9 @@ export enum CheckboxState {
   Unchecked = 'Unchecked',
   Indeterminate = 'Indeterminate',
 }
+
+export const tooltipMap = {
+  [CheckboxState.Checked]: 'Hide',
+  [CheckboxState.Unchecked]: 'Show',
+  [CheckboxState.Indeterminate]: 'Show',
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,10 +29,10 @@ export const VIEWER_HEIGHT: number = 580;
  * The VisibilitySelectionMap holds selection information from which we can derive the state of the agent
  * checkboxes and of the SelectionStateInfo. The keys are agent names and the array contains possible selections.
  * The VisibilitySelectionMap is generalied to be used for both hiding and highlighting selections.
- * if visMap[agentName] = [agentName] // the agent is not selected (default), and by extension, no display states are selected
- * if visMap[agentName] = [ ] // the agent is selected, and by extension all display states are selected
- * if visMap[agentName] = [ displayStateName1, displayStateName2... ] // some but not all display states are selected, the agent checkbox is by definition indeterminate
- * if a selection array would contain all the display state names, it should be changed to an empty array
+ * if visMap[agentName] = [agentName] // the agent is not selected (default), and by extension, no children are selected
+ * if visMap[agentName] = [ ] // the agent is selected, and by extension all children are selected
+ * if visMap[agentName] = [ childAgentName1, childAgentName2... ] // some but not all children are selected, the agent checkbox is by definition indeterminate
+ * if a selection array would contain all the child names, it should be changed to an empty array
  */
 export interface VisibilitySelectionMap {
   [key: string]: string[];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,6 +24,16 @@ export const SIDE_PANEL_WIDTH: number = 280;
 export const MIN_WIDTH_TO_SHOW_SIDE_PANEL: number = 580;
 export const VIEWER_INITIAL_WIDTH: number = 500;
 export const VIEWER_HEIGHT: number = 580;
+
+/**
+ * The VisibilitySelectionMap holds selection information from which we can derive the state of the agent
+ * checkboxes and of the SelectionStateInfo. The keys are agent names and the array contains possible selections.
+ * The VisibilitySelectionMap is generalied to be used for both hiding and highlighting selections.
+ * if visMap[agentName] = [agentName] // the agent is not selected (default), and by extension, no display states are selected
+ * if visMap[agentName] = [ ] // the agent is selected, and by extension all display states are selected
+ * if visMap[agentName] = [ displayStateName1, displayStateName2... ] // some but not all display states are selected, the agent checkbox is by definition indeterminate
+ * if a selection array would contain all the display state names, it should be changed to an empty array
+ */
 export interface VisibilitySelectionMap {
   [key: string]: string[];
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,15 +26,14 @@ export const VIEWER_INITIAL_WIDTH: number = 500;
 export const VIEWER_HEIGHT: number = 580;
 
 /**
- * The VisibilitySelectionMap holds selection information from which we can derive the state of the agent
- * checkboxes and of the SelectionStateInfo. The keys are agent names and the array contains possible selections.
- * The VisibilitySelectionMap is generalied to be used for both hiding and highlighting selections.
- * if visMap[agentName] = [agentName] // the agent is not selected (default), and by extension, no children are selected
- * if visMap[agentName] = [ ] // the agent is selected, and by extension all children are selected
- * if visMap[agentName] = [ childAgentName1, childAgentName2... ] // some but not all children are selected, the agent checkbox is by definition indeterminate
- * if a selection array would contain all the child names, it should be changed to an empty array
+ * The UserChangesMap stores user changes to highlighting and hiding checkboxes.
+ * If a user highlights an agent or display state, that "star" checkbox will be checked.
+ * If a user hides an agent or display state, that checkbox will be checked.
+ * The selection state info for the viewer is derived from these maps.
+ * The default state is to include the agent name, or if an agent has multiple display states,
+ * all of the display state names.
  */
-export interface VisibilitySelectionMap {
+export interface UserChangesMap {
   [key: string]: string[];
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,6 +32,9 @@ export const VIEWER_HEIGHT: number = 580;
  * The selection state info for the viewer is derived from these maps.
  * The default state is to include the agent name, or if an agent has multiple display states,
  * all of the display state names.
+ * userChangesMap[agentName] = [] means nothing is selected
+ * userChangesMap[agentName] = [agentName] means the agent is selected in a case with no display states
+ * userChangesMap[agentName] = [displayState1, displayState2] means whatever display states are in the array are selected
  */
 export interface UserChangesMap {
   [key: string]: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,24 +26,24 @@ export enum SelectionType {
   Highlight,
 }
 
-export enum AgentType {
+export enum AgentLevel {
   Agent,
-  DisplayState,
+  ChildAgent,
 }
 
 interface BaseCustomCheckboxProps {
   agentName: string;
-  agentType: AgentType;
+  agentLevel: AgentLevel;
 }
 
-export interface AgentProps extends BaseCustomCheckboxProps {
-  agentType: AgentType.Agent;
-  displayStateName?: never;
+export interface ParentAgentProps extends BaseCustomCheckboxProps {
+  agentLevel: AgentLevel.Agent;
+  childName?: never;
 }
 
-export interface DisplayStateProps extends BaseCustomCheckboxProps {
-  agentType: AgentType.DisplayState;
-  displayStateName: string;
+export interface ChildAgentProps extends BaseCustomCheckboxProps {
+  agentLevel: AgentLevel.ChildAgent;
+  childName: string;
 }
 
-export type CustomCheckboxProps = AgentProps | DisplayStateProps;
+export type CustomCheckboxProps = ParentAgentProps | ChildAgentProps;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { UIDisplayEntry } from '@aics/simularium-viewer/type-declarations/simularium/SelectionInterface';
+
 export interface TimeUnits {
   magnitude: number;
   name: string;
@@ -21,29 +23,11 @@ export interface HighlightDisplayOption {
   icon: JSX.Element;
 }
 
-export enum SelectionType {
-  Hide,
-  Highlight,
+export interface ChildCheckboxProps {
+  name: string;
+  parentName: string;
 }
 
-export enum AgentLevel {
-  Agent,
-  ChildAgent,
+export interface CheckboxProps {
+  agent: UIDisplayEntry;
 }
-
-interface BaseCustomCheckboxProps {
-  agentName: string;
-  agentLevel: AgentLevel;
-}
-
-export interface ParentAgentProps extends BaseCustomCheckboxProps {
-  agentLevel: AgentLevel.Agent;
-  childName?: never;
-}
-
-export interface ChildAgentProps extends BaseCustomCheckboxProps {
-  agentLevel: AgentLevel.ChildAgent;
-  childName: string;
-}
-
-export type CustomCheckboxProps = ParentAgentProps | ChildAgentProps;

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,3 +25,25 @@ export enum SelectionType {
   Hide,
   Highlight,
 }
+
+export enum AgentType {
+  Agent,
+  DisplayState,
+}
+
+interface BaseCustomCheckboxProps {
+  agentName: string;
+  agentType: AgentType;
+}
+
+export interface AgentProps extends BaseCustomCheckboxProps {
+  agentType: AgentType.Agent;
+  displayStateName?: never;
+}
+
+export interface DisplayStateProps extends BaseCustomCheckboxProps {
+  agentType: AgentType.DisplayState;
+  displayStateName: string;
+}
+
+export type CustomCheckboxProps = AgentProps | DisplayStateProps;

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,9 +25,12 @@ export interface HighlightDisplayOption {
 
 export interface ChildCheckboxProps {
   name: string;
-  parentName: string;
+  selections: string[];
+  clickHandler: () => void;
 }
 
 export interface CheckboxProps {
   agent: UIDisplayEntry;
+  selections: string[];
+  clickHandler: () => void;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,7 +22,6 @@ export const getNewMapAfterDisplayStateClick = (
 ): VisibilitySelectionMap => {
   const newMap: VisibilitySelectionMap = { ...currentVisibilityMap };
   const currentStates = currentVisibilityMap[agentName] || [];
-  const index = currentStates.indexOf(displayStateName);
   if (currentStates.length === 0) {
     const allOtherDisplayStates = allDisplayStates.filter(
       (name) => name !== displayStateName
@@ -30,7 +29,7 @@ export const getNewMapAfterDisplayStateClick = (
     newMap[agentName] = allOtherDisplayStates;
     return newMap;
   }
-  if (index !== -1) {
+  if (currentStates.indexOf(displayStateName) !== -1) {
     // Display state is currently selected, so unselect it
     newMap[agentName] = currentStates.filter(
       (state) => state !== displayStateName

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,30 +22,38 @@ export const getNewMapAfterDisplayStateClick = (
 ): VisibilitySelectionMap => {
   const newMap: VisibilitySelectionMap = { ...currentVisibilityMap };
   const currentStates = currentVisibilityMap[agentName] || [];
-  if (currentStates.length === 0) {
+
+  const isAgentFullySelected = currentStates.length === 0;
+  const nothingCurrentlySelected =
+    currentStates.length === 1 && currentStates[0] === agentName;
+  const isThisDisplayStateSelected = currentStates.includes(displayStateName);
+  const isSelectionNowEmpty = (): boolean => {
+    return newMap[agentName].length === 0;
+  };
+  const allDisplayStatesNowSelected = (): boolean => {
+    return newMap[agentName].length === allDisplayStates.length;
+  };
+
+  if (isAgentFullySelected) {
     const allOtherDisplayStates = allDisplayStates.filter(
       (name) => name !== displayStateName
     );
     newMap[agentName] = allOtherDisplayStates;
     return newMap;
-  }
-  if (currentStates.indexOf(displayStateName) !== -1) {
-    // Display state is currently selected, so unselect it
+  } else if (isThisDisplayStateSelected) {
     newMap[agentName] = currentStates.filter(
       (state) => state !== displayStateName
     );
-    if (newMap[agentName].length === 0) {
-      newMap[agentName] = [agentName]; // No display states left selected, so set to agent name only
+    if (isSelectionNowEmpty()) {
+      newMap[agentName] = [agentName];
     }
   } else {
-    // if array only includes agent name, replace it with clicked display state
-    if (currentStates.length === 1 && currentStates.includes(agentName)) {
+    if (nothingCurrentlySelected) {
       newMap[agentName] = [displayStateName];
     } else {
-      // if other display states are selected, add clicked display state
       newMap[agentName] = [...currentStates, displayStateName];
     }
-    if (newMap[agentName].length === allDisplayStates.length) {
+    if (allDisplayStatesNowSelected()) {
       newMap[agentName] = [];
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,15 +1,54 @@
 import { SelectionEntry, UIDisplayData } from '@aics/simularium-viewer';
 import { VisibilitySelectionMap } from './constants';
 
-export const getNewSelectionMap = (
+export const getNewMapAfterTopLevelCheckboxClick = (
   agentName: string,
   currentVisibilityMap: VisibilitySelectionMap
 ): VisibilitySelectionMap => {
   const newMap: VisibilitySelectionMap = { ...currentVisibilityMap };
-  if (currentVisibilityMap[agentName].length === 0) {
-    newMap[agentName] = [agentName];
-  } else {
+  if (currentVisibilityMap[agentName].includes(agentName)) {
     newMap[agentName] = [];
+  } else {
+    newMap[agentName] = [agentName];
+  }
+  return newMap;
+};
+
+export const getNewMapAfterDisplayStateClick = (
+  agentName: string,
+  displayStateName: string,
+  allDisplayStates: string[],
+  currentVisibilityMap: VisibilitySelectionMap
+): VisibilitySelectionMap => {
+  const newMap: VisibilitySelectionMap = { ...currentVisibilityMap };
+  const currentStates = currentVisibilityMap[agentName] || [];
+  const index = currentStates.indexOf(displayStateName);
+  if (currentStates.length === 0) {
+    const allOtherDisplayStates = allDisplayStates.filter(
+      (name) => name !== displayStateName
+    );
+    newMap[agentName] = allOtherDisplayStates;
+    return newMap;
+  }
+  if (index !== -1) {
+    // Display state is currently selected, so unselect it
+    newMap[agentName] = currentStates.filter(
+      (state) => state !== displayStateName
+    );
+    if (newMap[agentName].length === 0) {
+      newMap[agentName] = [agentName]; // No display states left selected, so set to agent name only
+    }
+  } else {
+    // if array only includes agent name, replace it with clicked display state
+    if (currentStates.length === 1 && currentStates.includes(agentName)) {
+      newMap[agentName] = [displayStateName];
+    } else {
+      // if other display states are selected, add clicked display state
+      newMap[agentName] = [...currentStates, displayStateName];
+    }
+    if (newMap[agentName].length === allDisplayStates.length) {
+      newMap[agentName] = [];
+    }
   }
   return newMap;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,15 +2,18 @@ import { SelectionEntry, UIDisplayData } from '@aics/simularium-viewer';
 import { UserChangesMap } from './constants';
 import { UIDisplayEntry } from '@aics/simularium-viewer/type-declarations/simularium/SelectionInterface';
 
-export const getSelectionAfterCheckboxClick = (
+export const updateUserChangesAfterCheckboxClick = (
   name: string,
   children: string[],
-  currentVisibilityMap: UserChangesMap
+  currentUserChanges: UserChangesMap
 ): UserChangesMap => {
-  const newMap: UserChangesMap = { ...currentVisibilityMap };
-  const selectionValue = children.length === 0 ? [name] : children;
-  if (currentVisibilityMap[name].length !== selectionValue.length) {
-    newMap[name] = selectionValue;
+  const newMap: UserChangesMap = { ...currentUserChanges };
+  // for a checkbox with no children, this is just the agent name
+  // for a checkbox with children it is an array of all the children
+  const allPossibleCheckboxes = children.length === 0 ? [name] : children;
+  // if they aren't currently all on, we turn them all on
+  if (currentUserChanges[name].length !== allPossibleCheckboxes.length) {
+    newMap[name] = allPossibleCheckboxes;
   } else {
     newMap[name] = [];
   }
@@ -20,9 +23,13 @@ export const getSelectionAfterCheckboxClick = (
 export const getSelectionAfterChildCheckboxClick = (
   name: string,
   parent: string,
-  currentVisibilityMap: UserChangesMap
+  currentUserChanges: UserChangesMap
 ): UserChangesMap => {
-  const newMap: UserChangesMap = { ...currentVisibilityMap };
+  const newMap: UserChangesMap = { ...currentUserChanges };
+  // Shouldn't ever hit this conditional, userChangesMap was not made correctly if so
+  if (newMap[parent] === undefined) {
+    throw new Error('Parent not found in map');
+  }
   if (newMap[parent].includes(name)) {
     newMap[parent] = newMap[parent].filter((child) => child !== name);
   } else {
@@ -32,40 +39,43 @@ export const getSelectionAfterChildCheckboxClick = (
 };
 
 export const getChildren = (agent: UIDisplayEntry): string[] => {
-  if (agent === undefined || agent.displayStates.length === 0) {
+  if (agent.displayStates.length === 0) {
     return [];
   }
-  return agent.displayStates.map((state) => state.name);
+  return agent.displayStates.map((state) => state.id);
 };
 
 export const convertMapToSelectionStateInfo = (
-  currentVisibilityMap: UserChangesMap,
+  currentUserChangesMap: UserChangesMap,
   uiData: UIDisplayData
 ): SelectionEntry[] => {
   const init: SelectionEntry[] = [];
   return uiData.reduce((acc, agent) => {
     // Theoretically, this block should never be hit because `agentVisibilityMap`
     // should always contain all the agents in `agentDisplayData`
-    if (!currentVisibilityMap[agent.name]) {
+    if (!currentUserChangesMap[agent.name]) {
       return acc;
     }
 
     if (!agent.displayStates.length) {
-      // if no tags and nothing is on, include agent name
-      if (!currentVisibilityMap[agent.name].length) {
+      // if no tags and user has changed from default, remove agent name
+      if (!currentUserChangesMap[agent.name].length) {
         acc.push({
           name: agent.name,
           tags: [],
         });
       }
     } else {
-      const hiddenTags = agent.displayStates
-        .filter((tag) => !currentVisibilityMap[agent.name].includes(tag.id))
+      // selected tags are either highlighted or hidden
+      // for highlighted: if its in the userChangesMap, it should be highlighted
+      // for hidden: if its in the userChangesMap, it should be hidden
+      const selectedTags = agent.displayStates
+        .filter((tag) => !currentUserChangesMap[agent.name].includes(tag.id))
         .map((displayState) => displayState.id);
-      if (hiddenTags.length) {
+      if (selectedTags.length) {
         acc.push({
           name: agent.name,
-          tags: hiddenTags,
+          tags: selectedTags,
         });
       }
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,7 +76,7 @@ export const convertMapToSelectionStateInfo = (
   }, init);
 };
 
-export const getInitialUserSelections = (uiDisplayData: UIDisplayData) => {
+export const makeEmptyUserSelections = (uiDisplayData: UIDisplayData) => {
   return uiDisplayData.reduce<UserChangesMap>((acc, agent) => {
     acc[agent.name] = [];
     return acc;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,13 +26,15 @@ export const getSelectionAfterChildCheckboxClick = (
   currentUserChanges: UserChangesMap
 ): UserChangesMap => {
   const newMap: UserChangesMap = { ...currentUserChanges };
+  const currentChildren = newMap[parent];
   // Shouldn't ever hit this conditional, userChangesMap was not made correctly if so
-  if (newMap[parent] === undefined) {
+  if (currentChildren === undefined) {
     throw new Error('Parent not found in map');
   }
-  const updatedChildren = newMap[parent].includes(name)
-    ? newMap[parent].filter((child) => child !== name)
-    : [...newMap[parent], name];
+  // toggles inclusion in the array
+  const updatedChildren = currentChildren.includes(name)
+    ? currentChildren.filter((child) => child !== name)
+    : [...currentChildren, name];
 
   newMap[parent] = updatedChildren;
   return newMap;
@@ -74,9 +76,7 @@ export const convertMapToSelectionStateInfo = (
   }, init);
 };
 
-export const mapUIDisplayDataToSelectionMap = (
-  uiDisplayData: UIDisplayData
-) => {
+export const getInitialUserSelections = (uiDisplayData: UIDisplayData) => {
   return uiDisplayData.reduce<UserChangesMap>((acc, agent) => {
     acc[agent.name] = [];
     return acc;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,10 +14,10 @@ export const getNewMapAfterTopLevelCheckboxClick = (
   return newMap;
 };
 
-export const getNewMapAfterDisplayStateClick = (
+export const getNewMapAfterChildAgentClick = (
   agentName: string,
-  displayStateName: string,
-  allDisplayStates: string[],
+  childAgentName: string,
+  allChildren: string[],
   currentVisibilityMap: VisibilitySelectionMap
 ): VisibilitySelectionMap => {
   const newMap: VisibilitySelectionMap = { ...currentVisibilityMap };
@@ -26,34 +26,34 @@ export const getNewMapAfterDisplayStateClick = (
   const isAgentFullySelected = currentStates.length === 0;
   const nothingCurrentlySelected =
     currentStates.length === 1 && currentStates[0] === agentName;
-  const isThisDisplayStateSelected = currentStates.includes(displayStateName);
+  const isThisChildSelected = currentStates.includes(childAgentName);
   const isSelectionNowEmpty = (): boolean => {
     return newMap[agentName].length === 0;
   };
-  const allDisplayStatesNowSelected = (): boolean => {
-    return newMap[agentName].length === allDisplayStates.length;
+  const allChildrenNowSelected = (): boolean => {
+    return newMap[agentName].length === allChildren.length;
   };
 
   if (isAgentFullySelected) {
-    const allOtherDisplayStates = allDisplayStates.filter(
-      (name) => name !== displayStateName
+    const allOtherChildren = allChildren.filter(
+      (name) => name !== childAgentName
     );
-    newMap[agentName] = allOtherDisplayStates;
+    newMap[agentName] = allOtherChildren;
     return newMap;
-  } else if (isThisDisplayStateSelected) {
+  } else if (isThisChildSelected) {
     newMap[agentName] = currentStates.filter(
-      (state) => state !== displayStateName
+      (state) => state !== childAgentName
     );
     if (isSelectionNowEmpty()) {
       newMap[agentName] = [agentName];
     }
   } else {
     if (nothingCurrentlySelected) {
-      newMap[agentName] = [displayStateName];
+      newMap[agentName] = [childAgentName];
     } else {
-      newMap[agentName] = [...currentStates, displayStateName];
+      newMap[agentName] = [...currentStates, childAgentName];
     }
-    if (allDisplayStatesNowSelected()) {
+    if (allChildrenNowSelected()) {
       newMap[agentName] = [];
     }
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "esModuleInterop":true,
     "jsx": "react",
-    "lib": ["es2015", "dom"],
+    "lib": ["es2017", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmitOnError": true,


### PR DESCRIPTION
Time Estimate or Size
=======
_Medium_

Problem
=======
We need to conditionally render rows of checkboxes/color swatch/name for an agent's display states.

Hopefully this is the final bit of agent selection functional work, prior to a styling PR.
Open to feedback/refactoring to move this along., there is definitely more than one way to do this feature.

Solution
========
In `AgentRow` define a function to map over displayStates called `getDisplayStateRows`

In `types` you'll see a union type for the different props a `Checkbox` can take, the purpose of this union type is to reduce the number of checks we need on possibly undefined props, and make it clear whether we are dealing with a top level agent, or a display state, without a lot of fuss. In turn we can use the same Hide and Highlight checkbox components for both levels of organizaton.

I still have only those two basic checkboxes, and two functions in Context for handling when they are clicked:
`handleVisibilityCheckboxChange` and `handleHightlightCheckboxChange`.

I find this collects the logic and makes it readable, and I don't think it's overly generalized. Functions to get checkbox state still live in the components.

I also updated tests.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Run the trajectory and click the button to show the display state rows.
2. Try the various checkbox combinations.

Screenshots (optional):
-----------------------
![Screenshot 2024-04-11 at 4 19 28 PM](https://github.com/simularium/nbsv/assets/24981838/4e393e1d-36d1-45c8-9e54-624f9257511c)

